### PR TITLE
Export locales.dart

### DIFF
--- a/device_preview/lib/device_preview.dart
+++ b/device_preview/lib/device_preview.dart
@@ -2,3 +2,4 @@ export 'src/devices/devices.dart';
 export 'src/device_preview.dart';
 export 'src/device_preview_data.dart';
 export 'src/screenshots/screenshot.dart';
+export 'src/locales.dart';


### PR DESCRIPTION
Hello! Many thanks for this plugin, it's very useful.
I've created this PR because I've noticed that the `availablesLocales` parameter in the `DevicePreview` constructor can't be used because `NamedLocale` is not exported. I think being able to choose only a small subset of locales would be very useful instead of having to always search for them in the search bar.