### PR TITLE
Don't send wrong MediaQuery while loading from preferences

### DIFF
--- a/device_preview/lib/src/device_preview.dart
+++ b/device_preview/lib/src/device_preview.dart
@@ -424,10 +424,6 @@ class DevicePreviewState extends State<DevicePreview> {
 
   @override
   void initState() {
-    _data = DevicePreviewData(
-      locale: _defaultLocale,
-    );
-
     _loadData();
     _onScreenshot = StreamController<DeviceScreenshot>.broadcast();
     super.initState();
@@ -447,6 +443,14 @@ class DevicePreviewState extends State<DevicePreview> {
     if (!widget.enabled) {
       return widget.builder(context);
     }
+
+    // Build the background gradient while preview data is not available
+    if (_data == null) {
+      return DecoratedBox(
+        decoration: DevicePreviewStyle.light().background,
+      );
+    }
+
     return DevicePreviewTheme(
       style: style,
       child: Directionality(


### PR DESCRIPTION
I found that while the device_preview plugin initializes the device size, the MediaQuery sent by the plugin corresponds to the iPhone 5, which can make some logic in the app wrong. 

For example: I use the code below to force portrait mode on phone and allow landscape only on tablet. Currently, the device preview sends the wrong MediaQuery at the start of the app, so during development I cannot test this custom logic unless I add somthing like `&& !usingDevicePreview` to the if.

```dart
final queryData = MediaQuery.of(context);
if (queryData.size.shortestSide < 600) {
    _portraitModeOnly();
}

void _portraitModeOnly() {
  SystemChrome.setPreferredOrientations([
    DeviceOrientation.portraitUp,
    DeviceOrientation.portraitDown,
  ]);
}
```

My proposed solution is to remove the initial default value for the variable `_data` and just render the gradient background while the device_preview settings are loading. 