### PR TITLE
Fix isToolbarVisible parameter

### DIFF
--- a/device_preview/lib/src/device_preview.dart
+++ b/device_preview/lib/src/device_preview.dart
@@ -85,15 +85,16 @@ class DevicePreview extends StatefulWidget {
     this.data,
     bool usePreferences = true,
     this.style,
-    bool areSettingsEnabled = true,
+    @Deprecated('Replaced by `isToolBarVisible`')
+    bool areSettingsEnabled,
     bool isToolBarVisible = true,
     this.availableLocales,
     this.onScreenshot,
     this.enabled = true,
   })  : assert(devices == null || devices.isNotEmpty),
         assert(usePreferences != null),
-        assert(areSettingsEnabled != null),
-        isToolBarVisible = isToolBarVisible || areSettingsEnabled,
+        assert(isToolBarVisible != null || areSettingsEnabled != null),
+        isToolBarVisible = areSettingsEnabled ?? areSettingsEnabled,
         usePreferences = (data == null) && usePreferences,
         super(key: key);
 

--- a/device_preview/lib/src/device_preview.dart
+++ b/device_preview/lib/src/device_preview.dart
@@ -94,7 +94,7 @@ class DevicePreview extends StatefulWidget {
   })  : assert(devices == null || devices.isNotEmpty),
         assert(usePreferences != null),
         assert(isToolBarVisible != null || areSettingsEnabled != null),
-        isToolBarVisible = areSettingsEnabled ?? areSettingsEnabled,
+        isToolBarVisible = areSettingsEnabled ?? isToolbarVisible,
         usePreferences = (data == null) && usePreferences,
         super(key: key);
 


### PR DESCRIPTION
Currently, the `isToolbarVisible` parameter is **ingored** by default as `areSettingsEnabled` is `true` by default.

This fixes this problem by setting `areSettingsEnabled` to `null` by default and only falling back to `areSettingsEnabled` when it is used.