### PR TITLE
fix selectDevice that provider was called outside tree 

### DIFF
--- a/device_preview/lib/src/device_preview.dart
+++ b/device_preview/lib/src/device_preview.dart
@@ -185,7 +185,7 @@ class DevicePreview extends StatefulWidget {
     BuildContext context,
     DeviceIdentifier deviceIdentifier,
   ) {
-    final store = Provider.of<DevicePreviewStore>(context);
+    final store = Provider.of<DevicePreviewStore>(context,listen: false);
     store.selectDevice(deviceIdentifier);
   }
 


### PR DESCRIPTION
A fix #81 when calling DevicePreview.selectDevice introduced in 0.5.3 is  throwing an error when calling 
`final store = Provider.of<DevicePreviewStore>(context);`
Tried to listen to a value exposed with provider, from outside of the widget tree.