### PR TITLE
Fix broken provided DevicePreviewStyle

### DIFF
--- a/device_preview/lib/src/device_preview.dart
+++ b/device_preview/lib/src/device_preview.dart
@@ -441,7 +441,7 @@ class _DevicePreviewState extends State<DevicePreview> {
               (DevicePreviewStore store) => store.data.isToolbarVisible,
             );
 
-        final style = DevicePreviewTheme.of(context);
+        final style = widget.style ?? DevicePreviewTheme.of(context);
 
         return Directionality(
           textDirection: TextDirection.ltr,


### PR DESCRIPTION
Currently when you make your own DevicePreviewStyle and pass it in to the constructor of DevicePreivew via its style property. It does not actually do anything. It always uses the default one via the inherited style. If you instead only use the inherited style if passed in widget.style is null, this issue is resolved and DevicePreview uses the provided DevicePreviewStyle one instead, if one is provided.