### PR TITLE
MediaQuery.of with nullOk has been removed from Flutter beta. Use maybeOf instead

### DIFF
--- a/device_preview/example/lib/gallery/studies/starter/app.dart
+++ b/device_preview/example/lib/gallery/studies/starter/app.dart
@@ -16,7 +16,7 @@ class StarterApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isDark = MediaQuery.of(context, nullOk: true)?.platformBrightness ==
+    final isDark = MediaQuery.maybeOf(context)?.platformBrightness ==
         Brightness.dark;
     return MaterialApp(
       title: 'Starter',

--- a/device_preview/lib/src/views/device_preview_style.dart
+++ b/device_preview/lib/src/views/device_preview_style.dart
@@ -83,7 +83,7 @@ class DevicePreviewTheme extends InheritedWidget {
     }
 
     // If toolbar position isn't supported, fallback to bottom.
-    final media = MediaQuery.of(context, nullOk: true) ??
+    final media = MediaQuery.maybeOf(context) ??
         MediaQueryData.fromWindow(WidgetsBinding.instance.window);
     if (!DevicePreviewTheme.isPositionAvailableForWidth(
         result.toolBar.position, media.size.width)) {


### PR DESCRIPTION
device_preview doesn't compile in Flutter 1.24 (beta) because the `nullOk` parameter has been removed from `MediaQuery.of`