### PR TITLE
Fix virtual keyboard padding calculation

### DIFF
--- a/device_frame/lib/src/keyboard/virtual_keyboard.dart
+++ b/device_frame/lib/src/keyboard/virtual_keyboard.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:device_frame/device_frame.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -43,11 +41,11 @@ class VirtualKeyboard extends StatelessWidget {
     );
     return mediaQuery.copyWith(
       viewInsets: insets,
-      viewPadding: EdgeInsets.only(
-        top: max(insets.top, mediaQuery.padding.top),
-        left: max(insets.left, mediaQuery.padding.left),
-        right: max(insets.right, mediaQuery.padding.right),
-        bottom: max(insets.bottom, mediaQuery.padding.bottom),
+      padding: EdgeInsets.only(
+        top: mediaQuery.padding.top,
+        left: mediaQuery.padding.left,
+        right: mediaQuery.padding.right,
+        bottom: 0,
       ),
     );
   }


### PR DESCRIPTION
Hello @aloisdeniel !
I've been experiencing some behavior issues with a feature on my app that relies on mediaquery insets calculation and I think the implementation of the virtual keyboard is incorrect according to the specs.
Here are the official specs that describe how viewInsets, viewPadding and padding behave. 
https://api.flutter.dev/flutter/dart-ui/FlutterView-class.html 

There is an interesting clip as well showing the differences  
https://flutter.github.io/assets-for-api-docs/assets/widgets/window_padding.mp4

I'm no expert on the topic but from the documentation I take that viewPadding does not change, it is tied to the device (notches for instance). What can be changed are the viewInsets or the padding.
I've done the following changes to the mediaQuery method, which make the feature I was describing work as expected.

Thanks for the great package!!