### PR TITLE
Fix https://github.com/aloisdeniel/flutter_device_preview/issues/118

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/flutter_device_preview.iml
+++ b/.idea/flutter_device_preview.iml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/device_frame/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/device_frame/build" />
+      <excludeFolder url="file://$MODULE_DIR$/device_preview/example/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/device_preview/example/build" />
+      <excludeFolder url="file://$MODULE_DIR$/tools/build" />
+      <excludeFolder url="file://$MODULE_DIR$/tools/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/device_preview/build" />
+      <excludeFolder url="file://$MODULE_DIR$/device_preview/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/device_frame/example/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/device_frame/example/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/flutter_device_preview.iml" filepath="$PROJECT_DIR$/.idea/flutter_device_preview.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/device_preview/lib/src/device_preview.dart
+++ b/device_preview/lib/src/device_preview.dart
@@ -354,10 +354,10 @@ class _DevicePreviewState extends State<DevicePreview> {
   }
 
   @override
-  void initState() {
+  void didChangeDependencies() {
     DeviceFrame.precache(context);
     _onScreenshot = StreamController<DeviceScreenshot>.broadcast();
-    super.initState();
+    super.didChangeDependencies();
   }
 
   Widget _buildPreview(BuildContext context) {


### PR DESCRIPTION
Fix for: https://github.com/aloisdeniel/flutter_device_preview/issues/118

Exception thrown says framework wants didChangeDependencies, so I just tried giving it the inits there instead of in initState. Also the initState was no longer needed then.

In my use and test cases this removed the thrown exception and everything still seems to work. I do of course recommend that you take a closer a look at the root cause of issue and run it through your tests. Still at least for me this removed the exception.

And yeah, obviously you can skip the .idea files 😃 