### PR TITLE
Add devices for app store screenshots

### DIFF
--- a/device_frame/assets/android_phone_android-16-9-aspect-ratio.svg
+++ b/device_frame/assets/android_phone_android-16-9-aspect-ratio.svg
@@ -1,0 +1,19 @@
+<svg width="414" height="736" viewBox="0 0 414 736" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="414" height="736" rx="0" fill="#FF0000" />
+	<!-- DEVICE PROPERTIES -->
+	<text fill="black" xml:space="preserve" style="white-space: pre" font-family="Roboto" font-size="14" letter-spacing="0em">
+		<tspan x="0" y="10">
+			name: Android Phone 16_9&#10;
+		</tspan>
+		<tspan x="0" y="30">
+			density: 3&#10;
+		</tspan>
+		<tspan x="0" y="50">
+			screen_size: 414x736&#10;
+		</tspan>
+		<tspan x="0" y="70">
+			safe_areas: 0,0,0,0|0,0,0,0
+		</tspan>
+	</text>
+</svg>

--- a/device_frame/assets/android_tablet_android-10-inch.svg
+++ b/device_frame/assets/android_tablet_android-10-inch.svg
@@ -1,0 +1,19 @@
+<svg width="720" height="1280" viewBox="0 0 720 1280" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="720" height="1280" rx="0" fill="#FF0000" />
+	<!-- DEVICE PROPERTIES -->
+	<text fill="black" xml:space="preserve" style="white-space: pre" font-family="Roboto" font-size="14" letter-spacing="0em">
+		<tspan x="0" y="10">
+			name: Android Tablet 10&quot;&#10;
+		</tspan>
+		<tspan x="0" y="30">
+			density: 3&#10;
+		</tspan>
+		<tspan x="0" y="50">
+			screen_size: 720x1280&#10;
+		</tspan>
+		<tspan x="0" y="70">
+			safe_areas: 0,0,0,0|0,0,0,0
+		</tspan>
+	</text>
+</svg>

--- a/device_frame/assets/android_tablet_android-7-inch.svg
+++ b/device_frame/assets/android_tablet_android-7-inch.svg
@@ -1,0 +1,19 @@
+<svg width="576" height="1024" viewBox="0 0 576 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="576" height="1024" rx="0" fill="#FF0000" />
+	<!-- DEVICE PROPERTIES -->
+	<text fill="black" xml:space="preserve" style="white-space: pre" font-family="Roboto" font-size="14" letter-spacing="0em">
+		<tspan x="0" y="10">
+			name: Android Tablet 7&quot;&#10;
+		</tspan>
+		<tspan x="0" y="30">
+			density: 3&#10;
+		</tspan>
+		<tspan x="0" y="50">
+			screen_size: 576x1024&#10;
+		</tspan>
+		<tspan x="0" y="70">
+			safe_areas: 0,0,0,0|0,0,0,0
+		</tspan>
+	</text>
+</svg>

--- a/device_frame/assets/ios_phone_iphone-5-5-inch.svg
+++ b/device_frame/assets/ios_phone_iphone-5-5-inch.svg
@@ -1,0 +1,19 @@
+<svg width="414" height="736" viewBox="0 0 414 736" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="414" height="736" rx="0" fill="#FF0000" />
+	<!-- DEVICE PROPERTIES -->
+	<text fill="black" xml:space="preserve" style="white-space: pre" font-family="Roboto" font-size="14" letter-spacing="0em">
+		<tspan x="0" y="10">
+			name: iPhone 5.5&quot;&#10;
+		</tspan>
+		<tspan x="0" y="30">
+			density: 3&#10;
+		</tspan>
+		<tspan x="0" y="50">
+			screen_size: 414x736&#10;
+		</tspan>
+		<tspan x="0" y="70">
+			safe_areas: 0,0,0,0|0,0,0,0
+		</tspan>
+	</text>
+</svg>

--- a/device_frame/assets/ios_phone_iphone-6-5-inch.svg
+++ b/device_frame/assets/ios_phone_iphone-6-5-inch.svg
@@ -1,0 +1,19 @@
+<svg width="414" height="896" viewBox="0 0 414 896" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="414" height="896" rx="0" fill="#FF0000" />
+	<!-- DEVICE PROPERTIES -->
+	<text fill="black" xml:space="preserve" style="white-space: pre" font-family="Roboto" font-size="14" letter-spacing="0em">
+		<tspan x="0" y="10">
+			name: iPhone 6.5&quot;&#10;
+		</tspan>
+		<tspan x="0" y="30">
+			density: 3&#10;
+		</tspan>
+		<tspan x="0" y="50">
+			screen_size: 414x896&#10;
+		</tspan>
+		<tspan x="0" y="70">
+			safe_areas: 0,0,0,0|0,0,0,0
+		</tspan>
+	</text>
+</svg>

--- a/device_frame/assets/ios_tablet_ipad-12-9-inch.svg
+++ b/device_frame/assets/ios_tablet_ipad-12-9-inch.svg
@@ -1,0 +1,19 @@
+<svg width="1024" height="1366" viewBox="0 0 1024 1366" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="1024" height="1366" rx="0" fill="#FF0000" />
+	<!-- DEVICE PROPERTIES -->
+	<text fill="black" xml:space="preserve" style="white-space: pre" font-family="Roboto" font-size="14" letter-spacing="0em">
+		<tspan x="0" y="10">
+			name: iPad 12.9&quot;&#10;
+		</tspan>
+		<tspan x="0" y="30">
+			density: 2&#10;
+		</tspan>
+		<tspan x="0" y="50">
+			screen_size: 1024x1366&#10;
+		</tspan>
+		<tspan x="0" y="70">
+			safe_areas: 0,0,0,0|0,0,0,0
+		</tspan>
+	</text>
+</svg>

--- a/device_frame/lib/src/devices.dart
+++ b/device_frame/lib/src/devices.dart
@@ -142,6 +142,24 @@ class IosDevices {
     'ipad',
   );
 
+  final iPhone5_5Inch = _find(
+    TargetPlatform.iOS,
+    DeviceType.phone,
+    'iphone-5-5-inch',
+  );
+
+  final iPhone6_5Inch = _find(
+    TargetPlatform.iOS,
+    DeviceType.phone,
+    'iphone-6-5-inch',
+  );
+
+  final iPad12_9Inch = _find(
+    TargetPlatform.iOS,
+    DeviceType.tablet,
+    'ipad-12-9-inch',
+  );
+
   List<DeviceInfo> get all => [
         iPadMini,
         iPadPro129,
@@ -150,6 +168,9 @@ class IosDevices {
         iPhone11,
         iPhone11Pro,
         iPhone11ProMax,
+        iPhone5_5Inch,
+        iPhone6_5Inch,
+        iPad12_9Inch
       ];
 }
 
@@ -205,6 +226,24 @@ class AndroidDevices {
     'nexus9',
   );
 
+  final android16_9AspectRatio = _find(
+    TargetPlatform.android,
+    DeviceType.phone,
+    'android-16-9-aspect-ratio',
+  );
+
+  final android7Inch = _find(
+    TargetPlatform.android,
+    DeviceType.tablet,
+    'android-7-inch',
+  );
+
+  final android10Inch = _find(
+    TargetPlatform.android,
+    DeviceType.tablet,
+    'android-10-inch',
+  );
+
   List<DeviceInfo> get all => [
         small,
         medium,
@@ -214,6 +253,9 @@ class AndroidDevices {
         samsungS20,
         samsungNote10Plus,
         nexus9,
+        android16_9AspectRatio,
+        android7Inch,
+        android10Inch
       ];
 }
 

--- a/device_frame/lib/src/devices.g.dart
+++ b/device_frame/lib/src/devices.g.dart
@@ -2836,6 +2836,46 @@ final _allDevices = [
   DeviceInfo(
     identifier: const DeviceIdentifier._(
       TargetPlatform.android,
+      DeviceType.tablet,
+      'android-10-inch',
+    ),
+    name: 'Android Tablet 10"',
+    pixelRatio: 3.0,
+    safeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    rotatedSafeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    screenPath: Path()
+      ..addRect(
+        Rect.fromLTWH(
+          0.0,
+          0.0,
+          720.0,
+          1280.0,
+        ),
+      ),
+    svgFrame:
+        '''<svg width="720" height="1280" viewBox="0 0 720 1280" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>
+''',
+    frameSize: Size(720.0, 1280.0),
+    screenSize: Size(720.0, 1280.0),
+  ),
+  DeviceInfo(
+    identifier: const DeviceIdentifier._(
+      TargetPlatform.android,
       DeviceType.phone,
       'pixel3',
     ),
@@ -3713,6 +3753,126 @@ final _allDevices = [
 ''',
     frameSize: Size(1854.0, 2722.0),
     screenSize: Size(768.0, 1024.0),
+  ),
+  DeviceInfo(
+    identifier: const DeviceIdentifier._(
+      TargetPlatform.android,
+      DeviceType.phone,
+      'android-16-9-aspect-ratio',
+    ),
+    name: 'Android Phone 16_9',
+    pixelRatio: 3.0,
+    safeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    rotatedSafeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    screenPath: Path()
+      ..addRect(
+        Rect.fromLTWH(
+          0.0,
+          0.0,
+          414.0,
+          736.0,
+        ),
+      ),
+    svgFrame:
+        '''<svg width="414" height="736" viewBox="0 0 414 736" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>
+''',
+    frameSize: Size(414.0, 736.0),
+    screenSize: Size(414.0, 736.0),
+  ),
+  DeviceInfo(
+    identifier: const DeviceIdentifier._(
+      TargetPlatform.android,
+      DeviceType.tablet,
+      'android-7-inch',
+    ),
+    name: 'Android Tablet 7"',
+    pixelRatio: 3.0,
+    safeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    rotatedSafeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    screenPath: Path()
+      ..addRect(
+        Rect.fromLTWH(
+          0.0,
+          0.0,
+          576.0,
+          1024.0,
+        ),
+      ),
+    svgFrame:
+        '''<svg width="576" height="1024" viewBox="0 0 576 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>
+''',
+    frameSize: Size(576.0, 1024.0),
+    screenSize: Size(576.0, 1024.0),
+  ),
+  DeviceInfo(
+    identifier: const DeviceIdentifier._(
+      TargetPlatform.iOS,
+      DeviceType.phone,
+      'iphone-5-5-inch',
+    ),
+    name: 'iPhone 5.5"',
+    pixelRatio: 3.0,
+    safeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    rotatedSafeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    screenPath: Path()
+      ..addRect(
+        Rect.fromLTWH(
+          0.0,
+          0.0,
+          414.0,
+          736.0,
+        ),
+      ),
+    svgFrame:
+        '''<svg width="414" height="736" viewBox="0 0 414 736" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>
+''',
+    frameSize: Size(414.0, 736.0),
+    screenSize: Size(414.0, 736.0),
   ),
   DeviceInfo(
     identifier: const DeviceIdentifier._(
@@ -6047,6 +6207,46 @@ final _allDevices = [
   DeviceInfo(
     identifier: const DeviceIdentifier._(
       TargetPlatform.iOS,
+      DeviceType.phone,
+      'iphone-6-5-inch',
+    ),
+    name: 'iPhone 6.5"',
+    pixelRatio: 3.0,
+    safeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    rotatedSafeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    screenPath: Path()
+      ..addRect(
+        Rect.fromLTWH(
+          0.0,
+          0.0,
+          414.0,
+          896.0,
+        ),
+      ),
+    svgFrame:
+        '''<svg width="414" height="896" viewBox="0 0 414 896" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>
+''',
+    frameSize: Size(414.0, 896.0),
+    screenSize: Size(414.0, 896.0),
+  ),
+  DeviceInfo(
+    identifier: const DeviceIdentifier._(
+      TargetPlatform.iOS,
       DeviceType.tablet,
       'ipad-pro12-9',
     ),
@@ -6643,6 +6843,46 @@ final _allDevices = [
 ''',
     frameSize: Size(918.0, 1848.0),
     screenSize: Size(414.0, 896.0),
+  ),
+  DeviceInfo(
+    identifier: const DeviceIdentifier._(
+      TargetPlatform.iOS,
+      DeviceType.tablet,
+      'ipad-12-9-inch',
+    ),
+    name: 'iPad 12.9"',
+    pixelRatio: 2.0,
+    safeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    rotatedSafeAreas: EdgeInsets.only(
+      left: 0.0,
+      top: 0.0,
+      right: 0.0,
+      bottom: 0.0,
+    ),
+    screenPath: Path()
+      ..addRect(
+        Rect.fromLTWH(
+          0.0,
+          0.0,
+          1024.0,
+          1366.0,
+        ),
+      ),
+    svgFrame:
+        '''<svg width="1024" height="1366" viewBox="0 0 1024 1366" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>
+''',
+    frameSize: Size(1024.0, 1366.0),
+    screenSize: Size(1024.0, 1366.0),
   ),
   DeviceInfo(
     identifier: const DeviceIdentifier._(

--- a/docs/content/usage/devices.md
+++ b/docs/content/usage/devices.md
@@ -34,6 +34,21 @@ This section lists all simulated devices included with Device Preview.
 <tr><th>Safe Area (Landscape)</th><td>left: 44.0, top: 0.0, right: 44.0, bottom: 21.0</td></tr>
 </table>
 
+#### iPhone 5.5"
+
+
+<table>
+<tr><td colspan="2">
+<img class="device-illustration" title="iPhone 5.5" illustration" src="content/usage/devices/ios_phone_iphone-5-5-inch.svg" style="width:200px;" />
+</td></tr>
+<tr><th>Platform</th><td>iOS</td></tr>
+<tr><th>Type</th><td>phone</td></tr>
+<tr><th>Pixel Ratio</th><td>3.0</td></tr>
+<tr><th>Screen size</th><td>414.0 x 736.0</td></tr>
+<tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+<tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+</table>
+
 #### iPhone 11
 
 
@@ -47,6 +62,21 @@ This section lists all simulated devices included with Device Preview.
 <tr><th>Screen size</th><td>414.0 x 896.0</td></tr>
 <tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 44.0, right: 0.0, bottom: 34.0</td></tr>
 <tr><th>Safe Area (Landscape)</th><td>left: 44.0, top: 0.0, right: 44.0, bottom: 21.0</td></tr>
+</table>
+
+#### iPhone 6.5"
+
+
+<table>
+<tr><td colspan="2">
+<img class="device-illustration" title="iPhone 6.5" illustration" src="content/usage/devices/ios_phone_iphone-6-5-inch.svg" style="width:200px;" />
+</td></tr>
+<tr><th>Platform</th><td>iOS</td></tr>
+<tr><th>Type</th><td>phone</td></tr>
+<tr><th>Pixel Ratio</th><td>3.0</td></tr>
+<tr><th>Screen size</th><td>414.0 x 896.0</td></tr>
+<tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+<tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
 </table>
 
 #### iPhone 11 Pro Max
@@ -107,6 +137,21 @@ This section lists all simulated devices included with Device Preview.
 <tr><th>Screen size</th><td>1024.0 x 1366.0</td></tr>
 <tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 24.0, right: 0.0, bottom: 20.0</td></tr>
 <tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 24.0, right: 0.0, bottom: 20.0</td></tr>
+</table>
+
+#### iPad 12.9"
+
+
+<table>
+<tr><td colspan="2">
+<img class="device-illustration" title="iPad 12.9" illustration" src="content/usage/devices/ios_tablet_ipad-12-9-inch.svg" style="width:200px;" />
+</td></tr>
+<tr><th>Platform</th><td>iOS</td></tr>
+<tr><th>Type</th><td>tablet</td></tr>
+<tr><th>Pixel Ratio</th><td>2.0</td></tr>
+<tr><th>Screen size</th><td>1024.0 x 1366.0</td></tr>
+<tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+<tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
 </table>
 
 ## Android
@@ -171,6 +216,21 @@ This section lists all simulated devices included with Device Preview.
 <tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 24.0, right: 0.0, bottom: 0.0</td></tr>
 </table>
 
+#### Android Phone 16_9
+
+
+<table>
+<tr><td colspan="2">
+<img class="device-illustration" title="Android Phone 16_9 illustration" src="content/usage/devices/android_phone_android-16-9-aspect-ratio.svg" style="width:200px;" />
+</td></tr>
+<tr><th>Platform</th><td>android</td></tr>
+<tr><th>Type</th><td>phone</td></tr>
+<tr><th>Pixel Ratio</th><td>3.0</td></tr>
+<tr><th>Screen size</th><td>414.0 x 736.0</td></tr>
+<tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+<tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+</table>
+
 #### Samsung Galaxy Note 10 Plus
 
 
@@ -199,6 +259,36 @@ This section lists all simulated devices included with Device Preview.
 <tr><th>Screen size</th><td>540.0 x 1080.0</td></tr>
 <tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 24.0, right: 0.0, bottom: 0.0</td></tr>
 <tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 24.0, right: 0.0, bottom: 0.0</td></tr>
+</table>
+
+#### Android Tablet 7"
+
+
+<table>
+<tr><td colspan="2">
+<img class="device-illustration" title="Android Tablet 7" illustration" src="content/usage/devices/android_tablet_android-7-inch.svg" style="width:200px;" />
+</td></tr>
+<tr><th>Platform</th><td>android</td></tr>
+<tr><th>Type</th><td>tablet</td></tr>
+<tr><th>Pixel Ratio</th><td>3.0</td></tr>
+<tr><th>Screen size</th><td>576.0 x 1024.0</td></tr>
+<tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+<tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+</table>
+
+#### Android Tablet 10"
+
+
+<table>
+<tr><td colspan="2">
+<img class="device-illustration" title="Android Tablet 10" illustration" src="content/usage/devices/android_tablet_android-10-inch.svg" style="width:200px;" />
+</td></tr>
+<tr><th>Platform</th><td>android</td></tr>
+<tr><th>Type</th><td>tablet</td></tr>
+<tr><th>Pixel Ratio</th><td>3.0</td></tr>
+<tr><th>Screen size</th><td>720.0 x 1280.0</td></tr>
+<tr><th>Safe Area (portrait)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
+<tr><th>Safe Area (Landscape)</th><td>left: 0.0, top: 0.0, right: 0.0, bottom: 0.0</td></tr>
 </table>
 
 #### Nexus 9

--- a/docs/content/usage/devices/android_phone_android-16-9-aspect-ratio copy.svg
+++ b/docs/content/usage/devices/android_phone_android-16-9-aspect-ratio copy.svg
@@ -1,0 +1,6 @@
+<svg width="414" height="736" viewBox="0 0 414 736" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="414" height="736" rx="0" fill="#58B5F0"/>
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>

--- a/docs/content/usage/devices/android_phone_android-16-9-aspect-ratio.svg
+++ b/docs/content/usage/devices/android_phone_android-16-9-aspect-ratio.svg
@@ -1,0 +1,6 @@
+<svg width="414" height="736" viewBox="0 0 414 736" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="414" height="736" rx="0" fill="#58B5F0"/>
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>

--- a/docs/content/usage/devices/android_tablet_android-10-inch.svg
+++ b/docs/content/usage/devices/android_tablet_android-10-inch.svg
@@ -1,0 +1,6 @@
+<svg width="720" height="1280" viewBox="0 0 720 1280" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="720" height="1280" rx="0" fill="#58B5F0"/>
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>

--- a/docs/content/usage/devices/android_tablet_android-7-inch.svg
+++ b/docs/content/usage/devices/android_tablet_android-7-inch.svg
@@ -1,0 +1,6 @@
+<svg width="576" height="1024" viewBox="0 0 576 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="576" height="1024" rx="0" fill="#58B5F0"/>
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>

--- a/docs/content/usage/devices/ios_phone_iphone-5-5-inch.svg
+++ b/docs/content/usage/devices/ios_phone_iphone-5-5-inch.svg
@@ -1,0 +1,6 @@
+<svg width="414" height="736" viewBox="0 0 414 736" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="414" height="736" rx="0" fill="#58B5F0"/>
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>

--- a/docs/content/usage/devices/ios_phone_iphone-6-5-inch.svg
+++ b/docs/content/usage/devices/ios_phone_iphone-6-5-inch.svg
@@ -1,0 +1,6 @@
+<svg width="414" height="896" viewBox="0 0 414 896" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="414" height="896" rx="0" fill="#58B5F0"/>
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>

--- a/docs/content/usage/devices/ios_tablet_ipad-12-9-inch.svg
+++ b/docs/content/usage/devices/ios_tablet_ipad-12-9-inch.svg
@@ -1,0 +1,6 @@
+<svg width="1024" height="1366" viewBox="0 0 1024 1366" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<!-- SCREEN SHAPE -->
+	<rect x="0" y="0" width="1024" height="1366" rx="0" fill="#58B5F0"/>
+	<!-- DEVICE PROPERTIES -->
+	
+</svg>


### PR DESCRIPTION
### What does this PR do?

Adds 6 new devices that allow developers to take screenshots that conform to all the size and resolution requirements of the iOS and Android app stores:

- iPhone 5.5" (1242x2208)
- iPhone 6.5" (1242x2688)
- iPad 12.9" (2048x2732)
- Android 16:9 Phone (1242x2208)
   - _Note: Same as iPhone 5.5"_
- Android 7" Tablet (1728x3072)
- Android 10" Tablet (2160x3840)

### Notes

The devices do not have any frames, since they only exist for screenshotting purposes. I used these devices to capture all the screenshots for [my Flutter app](https://inspiral.nathanfriend.io/) and can confirm it produces the correct sizes/aspect ratios for both stores.

If you don't like the lack of frames, I could consider surrounding each with a generic black square (maybe with some text describing its purpose), if that would make sense.

I'm also open to any naming changes if you think these could be more clear. Ideally, I would have put all of these devices in their own category/tab (e.g. "App store screenshots"), but it appears the current categories are backed by a built-in enum, so I wasn't sure how to go about this.

### Compliments

Thanks so much for putting this project together! It literally saved me hours. My app is a drawing app, so putting together a single screenshot-worthy drawing can take hours. Doing this 5 times for each screenshot was a total non-starter for me.

Also, the way this project uses the SVG files as input is brilliant!

Closes https://github.com/aloisdeniel/flutter_device_preview/issues/38
Closes https://github.com/aloisdeniel/flutter_device_preview/issues/85