### PR TITLE
Update flutter_svg and path_drawing to use proper null safety versions

### DIFF
--- a/device_frame/pubspec.yaml
+++ b/device_frame/pubspec.yaml
@@ -7,8 +7,8 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  flutter_svg: ^0.21.0-nullsafety.0
-  path_drawing: ^0.5.0-nullsafety.0
+  flutter_svg: ^0.22.0
+  path_drawing: ^0.5.1
   freezed_annotation: ^0.14.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
As a response to my opened #127 issue I updated the versions of `flutter_svg` and `path_drawing` to use the latest null safety versions instead off deprecated prereleases.