### PR TITLE
basicLocaleListResolution is throwing a imported from multiple packages conflict error

### DIFF
--- a/device_preview/lib/src/state/store.dart
+++ b/device_preview/lib/src/state/store.dart
@@ -9,6 +9,7 @@ import '../../device_preview.dart';
 import '../storage/storage.dart';
 import 'custom_device.dart';
 import 'state.dart';
+import '../../device_preview.dart' as device_preview;
 
 /// The store is a container for the current [state] of the device preview.
 ///
@@ -76,7 +77,7 @@ class DevicePreviewStore extends ChangeNotifier {
                 .toList()
             : defaultAvailableLocales;
 
-        final defaultLocale = basicLocaleListResolution(
+        final defaultLocale = device_preview.basicLocaleListResolution(
           WidgetsBinding.instance!.window.locales,
           availaiableLocales.map((x) => x!.locale).toList(),
         ).toString();


### PR DESCRIPTION
Error: 'basicLocaleListResolution' is imported from both 'package:flutter/src/widgets/app.dart' and 'package:device_preview/src/locales/locales.dart'.

Resolved the by specifying the import should be from locales.dart and not flutter's app.dart