### PR TITLE
Add dialog for change custom device size

### DIFF
--- a/device_preview/lib/src/views/tool_panel/sections/subsections/custom_device.dart
+++ b/device_preview/lib/src/views/tool_panel/sections/subsections/custom_device.dart
@@ -81,6 +81,7 @@ List<Widget> buildCustomDeviceTiles(BuildContext context) {
                   initialValue: customDevice.screenSize.width,
                   title: 'Change Width',
                 ).then((value) {
+                  if (value == null) return;
                   final store = context.read<DevicePreviewStore>();
                   store.updateCustomDevice(
                     customDevice.copyWith(
@@ -113,9 +114,10 @@ List<Widget> buildCustomDeviceTiles(BuildContext context) {
               onTap: () {
                 _openDeviceSizeAdjustDialog(
                   context: context,
-                  initialValue: customDevice.screenSize.width,
+                  initialValue: customDevice.screenSize.height,
                   title: 'Change Height',
                 ).then((value) {
+                  if (value == null) return;
                   final store = context.read<DevicePreviewStore>();
                   store.updateCustomDevice(
                     customDevice.copyWith(

--- a/device_preview/lib/src/views/tool_panel/sections/subsections/custom_device.dart
+++ b/device_preview/lib/src/views/tool_panel/sections/subsections/custom_device.dart
@@ -1,5 +1,67 @@
 part of 'device_model.dart';
 
+Future<dynamic> _openDeviceSizeAdjustDialog({
+  required BuildContext context,
+  required double initialValue,
+  double min = 128,
+  double max = 2688,
+  String? title,
+}) {
+  var formKey = GlobalKey<FormState>();
+  return showDialog(
+    context: context,
+    builder: (context) {
+      var navigator = Navigator.of(context);
+      var textEditingController =
+          TextEditingController(text: initialValue.toString());
+      textEditingController.selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: textEditingController.text.length,
+      );
+
+      return AlertDialog(
+        title: Text(title ?? 'Input Value'),
+        content: Form(
+          key: formKey,
+          child: TextFormField(
+            autofocus: true,
+            onSaved: (String? value) => navigator.pop(double.tryParse(value!)),
+            keyboardType: TextInputType.number,
+            validator: (value) {
+              var parsedDouble = 0.0;
+              try {
+                parsedDouble = double.tryParse(value!)!;
+              } catch (e) {
+                return 'Please input only numbers';
+              }
+              bool inBetweenMinMax = parsedDouble >= min && parsedDouble <= max;
+              if (!inBetweenMinMax) {
+                return 'Invalid range. ($min ~ $max)';
+              }
+              return null;
+            },
+            controller: textEditingController,
+          ),
+        ),
+        actions: [
+          TextButton(
+            child: const Text('Close'),
+            onPressed: navigator.pop,
+          ),
+          TextButton(
+            child: const Text('Confirm'),
+            onPressed: () {
+              if (formKey.currentState!.validate()) {
+                formKey.currentState!.save();
+              }
+            },
+          ),
+        ],
+      );
+    },
+  );
+}
+
 /// Create a set of tiles to fine tune a custom device.
 List<Widget> buildCustomDeviceTiles(BuildContext context) {
   final customDevice = context.select(
@@ -12,7 +74,23 @@ List<Widget> buildCustomDeviceTiles(BuildContext context) {
         if (customDevice != null) ...[
           ListTile(
             title: const Text('Width'),
-            trailing: Text(customDevice.screenSize.width.toString()),
+            trailing: GestureDetector(
+              onTap: () {
+                _openDeviceSizeAdjustDialog(
+                  context: context,
+                  initialValue: customDevice.screenSize.width,
+                  title: 'Change Width',
+                ).then((value) {
+                  final store = context.read<DevicePreviewStore>();
+                  store.updateCustomDevice(
+                    customDevice.copyWith(
+                      screenSize: Size(value, customDevice.screenSize.height),
+                    ),
+                  );
+                });
+              },
+              child: Text(customDevice.screenSize.width.toString()),
+            ),
             subtitle: Slider(
               value: customDevice.screenSize.width,
               onChanged: (v) {
@@ -30,7 +108,23 @@ List<Widget> buildCustomDeviceTiles(BuildContext context) {
           ),
           ListTile(
             title: const Text('Height'),
-            trailing: Text(customDevice.screenSize.height.toString()),
+            trailing: GestureDetector(
+              child: Text(customDevice.screenSize.height.toString()),
+              onTap: () {
+                _openDeviceSizeAdjustDialog(
+                  context: context,
+                  initialValue: customDevice.screenSize.width,
+                  title: 'Change Height',
+                ).then((value) {
+                  final store = context.read<DevicePreviewStore>();
+                  store.updateCustomDevice(
+                    customDevice.copyWith(
+                      screenSize: Size(customDevice.screenSize.width, value),
+                    ),
+                  );
+                });
+              },
+            ),
             subtitle: Slider(
               value: customDevice.screenSize.height,
               onChanged: (v) {


### PR DESCRIPTION
## Why I need to change width and height using input?

When flutter devs need device  size cannot divide by Slider's division 20.

So I add dialog into width and height.

Look this screenshot
<img width="182" alt="image" src="https://user-images.githubusercontent.com/1451365/143535486-34ce6382-5621-4a80-b5e1-53228801478d.png">


devs can set 1536x2152 easily. another options does not need dialog. They still useful enough.

<img width="1919" alt="image" src="https://user-images.githubusercontent.com/1451365/143535971-f15b0a16-3edf-463c-86f0-6a128ee852fb.png">


<img src="https://i.imgur.com/QvcZgy0.gif">