### PR TITLE
Fix unnecessary padding that appears above keyboard when it is opened.

### DIFF
--- a/device_preview/lib/src/device_preview.dart
+++ b/device_preview/lib/src/device_preview.dart
@@ -536,7 +536,11 @@ class _DevicePreviewState extends State<DevicePreview> {
                         : BorderRadius.zero;
                     final double rightPanelOffset =
                         !isSmall ? (isEnabled ? ToolPanel.panelWidth - 10 : (64 + mediaQuery.padding.right)) : 0;
-                    final double bottomPanelOffset = isSmall ? mediaQuery.padding.bottom + 52 : 0;
+                    final double bottomPanelOffset = isSmall
+                        ? mediaQuery.viewInsets.bottom > 0
+                            ? 0
+                            : mediaQuery.padding.bottom + 52
+                        : 0;
                     return Stack(
                       children: <Widget>[
                         if (isToolbarVisible && isSmall)


### PR DESCRIPTION
Here is the unnecessary padding indicated with red color.

<img width="465" alt="Screen Shot 2022-02-08 at 16 20 10" src="https://user-images.githubusercontent.com/40357552/152995530-7ebd97a3-1821-4d66-be19-455ea95c3e4a.png">
