### PR TITLE
Remove recursive export of file.dart

### DIFF
--- a/device_preview/lib/src/storage/file/file.dart
+++ b/device_preview/lib/src/storage/file/file.dart
@@ -1,3 +1,3 @@
-export 'file.dart'
+export 'file_mock.dart'
     if (dart.library.html) 'file_web.dart'
     if (dart.library.io) 'file_io.dart';


### PR DESCRIPTION
Because of this recursive export freezed fails to generate files with Stack Overflow exception
https://github.com/rrousselGit/freezed/issues/445#issuecomment-977806840