### PR TITLE
Fix the `plugins section` link in the `Options` page.

### DIFF
--- a/docs/content/usage/options.md
+++ b/docs/content/usage/options.md
@@ -62,7 +62,7 @@ By default, the available sections are :
 *  `AccessibilitySection()` : text scaling factory, color and navigation accessibility options
 *  `SettingsSection()` : the Device Preview theme (light or dark).
 
-See the [plugins section](/content/plugins/screenshots.) to learn more on how to add additionnal sections like ScreenshotSection or a custom one.
+See the [plugins section](/content/plugins/screenshot) to learn more on how to add additionnal sections like ScreenshotSection or a custom one.
 
 ##### Example
 

--- a/docs/content/usage/options.md
+++ b/docs/content/usage/options.md
@@ -62,7 +62,7 @@ By default, the available sections are :
 *  `AccessibilitySection()` : text scaling factory, color and navigation accessibility options
 *  `SettingsSection()` : the Device Preview theme (light or dark).
 
-See the [plugins section](/context/plugins/screenshots.) to learn more on how to add additionnal sections like ScreenshotSection or a custom one.
+See the [plugins section](/content/plugins/screenshots.) to learn more on how to add additionnal sections like ScreenshotSection or a custom one.
 
 ##### Example
 


### PR DESCRIPTION
Fixed a bug where the link to the [Screenshot Plugin page](https://aloisdeniel.github.io/flutter_device_preview/#/content/plugins/screenshot) on the [Options page](https://aloisdeniel.github.io/flutter_device_preview/#/content/usage/options) was incorrect and caused a 404 error 🛠️ 