### PR TITLE
Adding DeviceListView key

### DIFF
--- a/device_preview/lib/src/views/tool_panel/sections/subsections/device_model.dart
+++ b/device_preview/lib/src/views/tool_panel/sections/subsections/device_model.dart
@@ -124,6 +124,7 @@ class _PlatformModelPicker extends StatelessWidget {
     final byDeviceType =
         groupBy<DeviceInfo, DeviceType>(devices, (d) => d.identifier.type);
     return ListView(
+      key: const Key('DeviceListView'),
       children: [
         ...byDeviceType.entries
             .map(


### PR DESCRIPTION
[We](https://github.com/the-mac) just [created an issue](https://github.com/the-mac/integration_test_preview/issues/2) that mentions the device_preview needing to be explicitly referenced (without a device_preview git reference to our fork).
```yaml
name: integration_test_preview
description: Integration Test Preview has pre-configured methods that allow for faster test deployment for end to end (e2e) test coverage (using Android and iOS platform UIs). This package is based upon the Integration Test Helper and Device Preview packages, and does much more with the combination of the two of them. It also allows for specific device size preview screenshots for the app stores, generated locally in your project path.

  device_preview:
    git:
      url: https://github.com/the-mac/flutter_device_preview.git
      path: device_preview/
      ref: master
```

We will move forward by referencing our package through the git repo, but would like to ask for approval (or admin status to approve) this pull request, and a few others if needed.

This key allows for scrolling the devices list programatically. We have a repo that uses the Device Preview package and it requires scrolling on the devices.

Alternatively, I was able to run most of the example test using scrollToListTypeItemText:
```dart

        final listFinder = find.byType(listType, skipOffstage: true);
        final itemFinder = find.text(itemText);
```

```dart

    var newScreenName = device.name;
    await scrollToListTypeItemText(ListView, newScreenName);

```

Instead of this pull request change using scrollToListItemText:

```dart

        final listFinder = find.byKey(Key(listKey));
        final itemFinder = find.text(itemText);

```

```dart

    var newScreenName = device.name;
    await scrollToListItemText('DeviceListView', newScreenName);

```

```dart

    final byDeviceType =
        groupBy<DeviceInfo, DeviceType>(devices, (d) => d.identifier.type);
    return ListView(
      key: const Key('DeviceListView'),
      children: [
        ...byDeviceType.entries

```

But, the final result was that I can't as a dev use this test framework with any lists, unless I use some type of complicated predicate.

```bash

VMServiceFlutterDriver: request_data message is taking a long time to complete...
I/flutter (20880): Showing Hello, Flutter!
I/flutter (20880): Setting up screenshot: screenshots/ios/hello_flutter.png
I/flutter (20880): Showing Languages
I/flutter (20880): Setting up screenshot: screenshots/ios/languages_list.png
I/flutter (20880): Setting up screenshot: screenshots/ios/language_python.png
I/flutter (20880): Showing Counter Sample
I/flutter (20880): Setting up screenshot: screenshots/ios/counter_sample.png
I/flutter (20880): Setting up screenshot: screenshots/ios/counter_sample_4.png
I/flutter (20880): Showing Preferences
I/flutter (20880): Setting up screenshot: screenshots/ios/preferences_start.png
I/flutter (20880): Showing Counter Sample
I/flutter (20880): Showing Preferences
I/flutter (20880): Setting up screenshot: screenshots/ios/preferences_end.png
I/flutter (20880): ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
I/flutter (20880): The following StateError was thrown running a test:
I/flutter (20880): Bad state: Too many elements
I/flutter (20880): 
I/flutter (20880): When the exception was thrown, this was the stack:
I/flutter (20880): #0      Iterable.single (dart:core/iterable.dart:522:24)
I/flutter (20880): #1      WidgetController.widget (package:flutter_test/src/controller.dart:69:30)
I/flutter (20880): #2      WidgetController.scrollUntilVisible.<anonymous closure> (package:flutter_test/src/controller.dart:1190:15)
I/flutter (20880): #3      WidgetController.scrollUntilVisible.<anonymous closure> (package:flutter_test/src/controller.dart:1188:39)
I/flutter (20880): #6      TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:71:41)
I/flutter (20880): #7      WidgetController.scrollUntilVisible (package:flutter_test/src/controller.dart:1188:27)
I/flutter (20880): #8      BaseIntegrationTest.scrollToListTypeItemText (package:integration_test_helper/integration_test_helper.dart:197:22)
I/flutter (20880): #9      IntegrationTestPreview._selectNextScreenType (package:integration_test_preview/integration_test.dart:138:11)
I/flutter (20880): <asynchronous suspension>
I/flutter (20880): #10     IntegrationTestPreview.testDevicesEndToEnd (package:integration_test_preview/integration_test.dart:77:7)
I/flutter (20880): <asynchronous suspension>
I/flutter (20880): #11     main.<anonymous closure> (file:///Users/cmiller/git/packages/flutter/integration_test_preview/example/integration_test/app_test.dart:29:11)
I/flutter (20880): <asynchronous suspension>
I/flutter (20880): #12     testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:170:15)
I/flutter (20880): <asynchronous suspension>
I/flutter (20880): #13     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:806:5)
I/flutter (20880): <asynchronous suspension>
I/flutter (20880): (elided 2 frames from dart:async)
I/flutter (20880): 
I/flutter (20880): The test description was:
I/flutter (20880):   Testing end to end multi-screen integration
I/flutter (20880): ════════════════════════════════════════════════════════════════════════════════════════════════════
I/flutter (20880): 01:58 +0: Testing end to end multi-screen integration [E]
I/flutter (20880):   Test failed. See exception logs above.
I/flutter (20880):   The test description was: Testing end to end multi-screen integration
I/flutter (20880):   
I/flutter (20880): Consider enabling the flag chain-stack-traces to receive more detailed exceptions.
I/flutter (20880): For example, 'dart test --chain-stack-traces'.
I/flutter (20880): 01:58 +0 -1: (tearDownAll)
W/example.exampl(20880): Accessing hidden method Lsun/misc/Unsafe;->compareAndSwapObject(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z (greylist, linking,
allowed)
I/flutter (20880): 02:00 +1 -1: Some tests failed.
File: 'screenshots/ios/hello_flutter.png'
File: 'screenshots/ios/languages_list.png'
File: 'screenshots/ios/language_python.png'
File: 'screenshots/ios/counter_sample.png'
File: 'screenshots/ios/counter_sample_4.png'
File: 'screenshots/ios/preferences_start.png'
File: 'screenshots/ios/preferences_end.png'
Failure Details:
Failure in method: Testing end to end multi-screen integration
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following StateError was thrown running a test:
Bad state: Too many elements

When the exception was thrown, this was the stack:
#0      Iterable.single (dart:core/iterable.dart:522:24)
#1      WidgetController.widget (package:flutter_test/src/controller.dart:69:30)
#2      WidgetController.scrollUntilVisible.<anonymous closure> (package:flutter_test/src/controller.dart:1190:15)
#3      WidgetController.scrollUntilVisible.<anonymous closure> (package:flutter_test/src/controller.dart:1188:39)
#6      TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:71:41)
#7      WidgetController.scrollUntilVisible (package:flutter_test/src/controller.dart:1188:27)
#8      BaseIntegrationTest.scrollToListTypeItemText (package:integration_test_helper/integration_test_helper.dart:197:22)
#9      IntegrationTestPreview._selectNextScreenType (package:integration_test_preview/integration_test.dart:138:11)
<asynchronous suspension>
#10     IntegrationTestPreview.testDevicesEndToEnd (package:integration_test_preview/integration_test.dart:77:7)
<asynchronous suspension>
#11     main.<anonymous closure> (file:///Users/cmiller/git/packages/flutter/integration_test_preview/example/integration_test/app_test.dart:29:11)
<asynchronous suspension>
#12     testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:170:15)
<asynchronous suspension>
#13     TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:806:5)
<asynchronous suspension>
(elided 2 frames from dart:async)

The test description was:
  Testing end to end multi-screen integration
═════════════════════════════════════════════════════════════════

end of failure 1

```