### PR TITLE
[upgrade] freezed 2.0.3

### DIFF
--- a/device_frame/pubspec.yaml
+++ b/device_frame/pubspec.yaml
@@ -1,13 +1,13 @@
 name: device_frame
 description: Mockups for common devices.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/aloisdeniel/flutter_device_preview/device_frame
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  freezed_annotation: ^1.0.0
+  freezed_annotation: ^2.0.3
   flutter:
     sdk: flutter
 
@@ -16,7 +16,7 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.1.4
   json_serializable: ^6.0.1
-  freezed: ^1.0.0
+  freezed: ^2.0.3
   flutter_lints: ^1.0.4
   xml: ^5.3.1
   recase: ^4.0.0


### PR DESCRIPTION
I'm using storybook_flutter for demo and it feed great, but it has some conflict with freezed & freezed_annotation, try to changes the version and not seem to be errors. 