### PR TITLE
Add zooming & fix frame sizing

### DIFF
--- a/device_preview/lib/src/state/state.dart
+++ b/device_preview/lib/src/state/state.dart
@@ -1,9 +1,9 @@
 import 'package:device_preview/device_preview.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../utilities/json_converters.dart';
-import 'package:flutter/foundation.dart';
 
 part 'state.freezed.dart';
 part 'state.g.dart';
@@ -65,6 +65,9 @@ class DevicePreviewData with _$DevicePreviewData {
 
     /// Indicate whether the virtual keyboard is visible.
     @Default(false) bool isVirtualKeyboardVisible,
+
+    /// Current zoom level
+    @Default(null) int? zoomLevel,
 
     /// Indicate whether animations are disabled.
     @Default(false) bool disableAnimations,

--- a/device_preview/lib/src/state/state.freezed.dart
+++ b/device_preview/lib/src/state/state.freezed.dart
@@ -27,9 +27,9 @@ mixin _$DevicePreviewState {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? notInitialized,
-    TResult Function()? initializing,
-    TResult Function(List<DeviceInfo> devices, List<NamedLocale> locales,
+    TResult? Function()? notInitialized,
+    TResult? Function()? initializing,
+    TResult? Function(List<DeviceInfo> devices, List<NamedLocale> locales,
             DevicePreviewData data)?
         initialized,
   }) =>
@@ -55,9 +55,9 @@ mixin _$DevicePreviewState {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_NotInitializedDevicePreviewState value)? notInitialized,
-    TResult Function(_InitializingDevicePreviewState value)? initializing,
-    TResult Function(_InitializedDevicePreviewState value)? initialized,
+    TResult? Function(_NotInitializedDevicePreviewState value)? notInitialized,
+    TResult? Function(_InitializingDevicePreviewState value)? initializing,
+    TResult? Function(_InitializedDevicePreviewState value)? initialized,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -74,17 +74,18 @@ mixin _$DevicePreviewState {
 abstract class $DevicePreviewStateCopyWith<$Res> {
   factory $DevicePreviewStateCopyWith(
           DevicePreviewState value, $Res Function(DevicePreviewState) then) =
-      _$DevicePreviewStateCopyWithImpl<$Res>;
+      _$DevicePreviewStateCopyWithImpl<$Res, DevicePreviewState>;
 }
 
 /// @nodoc
-class _$DevicePreviewStateCopyWithImpl<$Res>
+class _$DevicePreviewStateCopyWithImpl<$Res, $Val extends DevicePreviewState>
     implements $DevicePreviewStateCopyWith<$Res> {
   _$DevicePreviewStateCopyWithImpl(this._value, this._then);
 
-  final DevicePreviewState _value;
   // ignore: unused_field
-  final $Res Function(DevicePreviewState) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 }
 
 /// @nodoc
@@ -97,16 +98,13 @@ abstract class _$$_NotInitializedDevicePreviewStateCopyWith<$Res> {
 
 /// @nodoc
 class __$$_NotInitializedDevicePreviewStateCopyWithImpl<$Res>
-    extends _$DevicePreviewStateCopyWithImpl<$Res>
+    extends _$DevicePreviewStateCopyWithImpl<$Res,
+        _$_NotInitializedDevicePreviewState>
     implements _$$_NotInitializedDevicePreviewStateCopyWith<$Res> {
   __$$_NotInitializedDevicePreviewStateCopyWithImpl(
       _$_NotInitializedDevicePreviewState _value,
       $Res Function(_$_NotInitializedDevicePreviewState) _then)
-      : super(_value, (v) => _then(v as _$_NotInitializedDevicePreviewState));
-
-  @override
-  _$_NotInitializedDevicePreviewState get _value =>
-      super._value as _$_NotInitializedDevicePreviewState;
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -153,9 +151,9 @@ class _$_NotInitializedDevicePreviewState
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? notInitialized,
-    TResult Function()? initializing,
-    TResult Function(List<DeviceInfo> devices, List<NamedLocale> locales,
+    TResult? Function()? notInitialized,
+    TResult? Function()? initializing,
+    TResult? Function(List<DeviceInfo> devices, List<NamedLocale> locales,
             DevicePreviewData data)?
         initialized,
   }) {
@@ -193,9 +191,9 @@ class _$_NotInitializedDevicePreviewState
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_NotInitializedDevicePreviewState value)? notInitialized,
-    TResult Function(_InitializingDevicePreviewState value)? initializing,
-    TResult Function(_InitializedDevicePreviewState value)? initialized,
+    TResult? Function(_NotInitializedDevicePreviewState value)? notInitialized,
+    TResult? Function(_InitializingDevicePreviewState value)? initializing,
+    TResult? Function(_InitializedDevicePreviewState value)? initialized,
   }) {
     return notInitialized?.call(this);
   }
@@ -230,16 +228,13 @@ abstract class _$$_InitializingDevicePreviewStateCopyWith<$Res> {
 
 /// @nodoc
 class __$$_InitializingDevicePreviewStateCopyWithImpl<$Res>
-    extends _$DevicePreviewStateCopyWithImpl<$Res>
+    extends _$DevicePreviewStateCopyWithImpl<$Res,
+        _$_InitializingDevicePreviewState>
     implements _$$_InitializingDevicePreviewStateCopyWith<$Res> {
   __$$_InitializingDevicePreviewStateCopyWithImpl(
       _$_InitializingDevicePreviewState _value,
       $Res Function(_$_InitializingDevicePreviewState) _then)
-      : super(_value, (v) => _then(v as _$_InitializingDevicePreviewState));
-
-  @override
-  _$_InitializingDevicePreviewState get _value =>
-      super._value as _$_InitializingDevicePreviewState;
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -286,9 +281,9 @@ class _$_InitializingDevicePreviewState
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? notInitialized,
-    TResult Function()? initializing,
-    TResult Function(List<DeviceInfo> devices, List<NamedLocale> locales,
+    TResult? Function()? notInitialized,
+    TResult? Function()? initializing,
+    TResult? Function(List<DeviceInfo> devices, List<NamedLocale> locales,
             DevicePreviewData data)?
         initialized,
   }) {
@@ -326,9 +321,9 @@ class _$_InitializingDevicePreviewState
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_NotInitializedDevicePreviewState value)? notInitialized,
-    TResult Function(_InitializingDevicePreviewState value)? initializing,
-    TResult Function(_InitializedDevicePreviewState value)? initialized,
+    TResult? Function(_NotInitializedDevicePreviewState value)? notInitialized,
+    TResult? Function(_InitializingDevicePreviewState value)? initializing,
+    TResult? Function(_InitializedDevicePreviewState value)? initialized,
   }) {
     return initializing?.call(this);
   }
@@ -359,6 +354,7 @@ abstract class _$$_InitializedDevicePreviewStateCopyWith<$Res> {
           _$_InitializedDevicePreviewState value,
           $Res Function(_$_InitializedDevicePreviewState) then) =
       __$$_InitializedDevicePreviewStateCopyWithImpl<$Res>;
+  @useResult
   $Res call(
       {List<DeviceInfo> devices,
       List<NamedLocale> locales,
@@ -369,33 +365,31 @@ abstract class _$$_InitializedDevicePreviewStateCopyWith<$Res> {
 
 /// @nodoc
 class __$$_InitializedDevicePreviewStateCopyWithImpl<$Res>
-    extends _$DevicePreviewStateCopyWithImpl<$Res>
+    extends _$DevicePreviewStateCopyWithImpl<$Res,
+        _$_InitializedDevicePreviewState>
     implements _$$_InitializedDevicePreviewStateCopyWith<$Res> {
   __$$_InitializedDevicePreviewStateCopyWithImpl(
       _$_InitializedDevicePreviewState _value,
       $Res Function(_$_InitializedDevicePreviewState) _then)
-      : super(_value, (v) => _then(v as _$_InitializedDevicePreviewState));
+      : super(_value, _then);
 
-  @override
-  _$_InitializedDevicePreviewState get _value =>
-      super._value as _$_InitializedDevicePreviewState;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? devices = freezed,
-    Object? locales = freezed,
-    Object? data = freezed,
+    Object? devices = null,
+    Object? locales = null,
+    Object? data = null,
   }) {
     return _then(_$_InitializedDevicePreviewState(
-      devices: devices == freezed
+      devices: null == devices
           ? _value._devices
           : devices // ignore: cast_nullable_to_non_nullable
               as List<DeviceInfo>,
-      locales: locales == freezed
+      locales: null == locales
           ? _value._locales
           : locales // ignore: cast_nullable_to_non_nullable
               as List<NamedLocale>,
-      data: data == freezed
+      data: null == data
           ? _value.data
           : data // ignore: cast_nullable_to_non_nullable
               as DevicePreviewData,
@@ -403,6 +397,7 @@ class __$$_InitializedDevicePreviewStateCopyWithImpl<$Res>
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $DevicePreviewDataCopyWith<$Res> get data {
     return $DevicePreviewDataCopyWith<$Res>(_value.data, (value) {
       return _then(_value.copyWith(data: value));
@@ -468,7 +463,7 @@ class _$_InitializedDevicePreviewState
             other is _$_InitializedDevicePreviewState &&
             const DeepCollectionEquality().equals(other._devices, _devices) &&
             const DeepCollectionEquality().equals(other._locales, _locales) &&
-            const DeepCollectionEquality().equals(other.data, data));
+            (identical(other.data, data) || other.data == data));
   }
 
   @override
@@ -476,10 +471,11 @@ class _$_InitializedDevicePreviewState
       runtimeType,
       const DeepCollectionEquality().hash(_devices),
       const DeepCollectionEquality().hash(_locales),
-      const DeepCollectionEquality().hash(data));
+      data);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_InitializedDevicePreviewStateCopyWith<_$_InitializedDevicePreviewState>
       get copyWith => __$$_InitializedDevicePreviewStateCopyWithImpl<
           _$_InitializedDevicePreviewState>(this, _$identity);
@@ -499,9 +495,9 @@ class _$_InitializedDevicePreviewState
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? notInitialized,
-    TResult Function()? initializing,
-    TResult Function(List<DeviceInfo> devices, List<NamedLocale> locales,
+    TResult? Function()? notInitialized,
+    TResult? Function()? initializing,
+    TResult? Function(List<DeviceInfo> devices, List<NamedLocale> locales,
             DevicePreviewData data)?
         initialized,
   }) {
@@ -539,9 +535,9 @@ class _$_InitializedDevicePreviewState
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(_NotInitializedDevicePreviewState value)? notInitialized,
-    TResult Function(_InitializingDevicePreviewState value)? initializing,
-    TResult Function(_InitializedDevicePreviewState value)? initialized,
+    TResult? Function(_NotInitializedDevicePreviewState value)? notInitialized,
+    TResult? Function(_InitializingDevicePreviewState value)? initializing,
+    TResult? Function(_InitializedDevicePreviewState value)? initialized,
   }) {
     return initialized?.call(this);
   }
@@ -569,13 +565,13 @@ abstract class _InitializedDevicePreviewState implements DevicePreviewState {
       _$_InitializedDevicePreviewState;
 
   /// The list of all available devices.
-  List<DeviceInfo> get devices => throw _privateConstructorUsedError;
+  List<DeviceInfo> get devices;
 
   /// The list of all available locales.
-  List<NamedLocale> get locales => throw _privateConstructorUsedError;
+  List<NamedLocale> get locales;
 
   /// The user settings of the preview.
-  DevicePreviewData get data => throw _privateConstructorUsedError;
+  DevicePreviewData get data;
   @JsonKey(ignore: true)
   _$$_InitializedDevicePreviewStateCopyWith<_$_InitializedDevicePreviewState>
       get copyWith => throw _privateConstructorUsedError;
@@ -614,6 +610,9 @@ mixin _$DevicePreviewData {
   /// Indicate whether the virtual keyboard is visible.
   bool get isVirtualKeyboardVisible => throw _privateConstructorUsedError;
 
+  /// Current zoom level
+  int? get zoomLevel => throw _privateConstructorUsedError;
+
   /// Indicate whether animations are disabled.
   bool get disableAnimations => throw _privateConstructorUsedError;
 
@@ -647,7 +646,8 @@ mixin _$DevicePreviewData {
 abstract class $DevicePreviewDataCopyWith<$Res> {
   factory $DevicePreviewDataCopyWith(
           DevicePreviewData value, $Res Function(DevicePreviewData) then) =
-      _$DevicePreviewDataCopyWithImpl<$Res>;
+      _$DevicePreviewDataCopyWithImpl<$Res, DevicePreviewData>;
+  @useResult
   $Res call(
       {bool isToolbarVisible,
       bool isEnabled,
@@ -658,6 +658,7 @@ abstract class $DevicePreviewDataCopyWith<$Res> {
       bool isDarkMode,
       bool boldText,
       bool isVirtualKeyboardVisible,
+      int? zoomLevel,
       bool disableAnimations,
       bool highContrast,
       bool accessibleNavigation,
@@ -672,125 +673,134 @@ abstract class $DevicePreviewDataCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$DevicePreviewDataCopyWithImpl<$Res>
+class _$DevicePreviewDataCopyWithImpl<$Res, $Val extends DevicePreviewData>
     implements $DevicePreviewDataCopyWith<$Res> {
   _$DevicePreviewDataCopyWithImpl(this._value, this._then);
 
-  final DevicePreviewData _value;
   // ignore: unused_field
-  final $Res Function(DevicePreviewData) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isToolbarVisible = freezed,
-    Object? isEnabled = freezed,
-    Object? orientation = freezed,
+    Object? isToolbarVisible = null,
+    Object? isEnabled = null,
+    Object? orientation = null,
     Object? deviceIdentifier = freezed,
-    Object? locale = freezed,
-    Object? isFrameVisible = freezed,
-    Object? isDarkMode = freezed,
-    Object? boldText = freezed,
-    Object? isVirtualKeyboardVisible = freezed,
-    Object? disableAnimations = freezed,
-    Object? highContrast = freezed,
-    Object? accessibleNavigation = freezed,
-    Object? invertColors = freezed,
-    Object? pluginData = freezed,
-    Object? textScaleFactor = freezed,
+    Object? locale = null,
+    Object? isFrameVisible = null,
+    Object? isDarkMode = null,
+    Object? boldText = null,
+    Object? isVirtualKeyboardVisible = null,
+    Object? zoomLevel = freezed,
+    Object? disableAnimations = null,
+    Object? highContrast = null,
+    Object? accessibleNavigation = null,
+    Object? invertColors = null,
+    Object? pluginData = null,
+    Object? textScaleFactor = null,
     Object? settings = freezed,
     Object? customDevice = freezed,
   }) {
     return _then(_value.copyWith(
-      isToolbarVisible: isToolbarVisible == freezed
+      isToolbarVisible: null == isToolbarVisible
           ? _value.isToolbarVisible
           : isToolbarVisible // ignore: cast_nullable_to_non_nullable
               as bool,
-      isEnabled: isEnabled == freezed
+      isEnabled: null == isEnabled
           ? _value.isEnabled
           : isEnabled // ignore: cast_nullable_to_non_nullable
               as bool,
-      orientation: orientation == freezed
+      orientation: null == orientation
           ? _value.orientation
           : orientation // ignore: cast_nullable_to_non_nullable
               as Orientation,
-      deviceIdentifier: deviceIdentifier == freezed
+      deviceIdentifier: freezed == deviceIdentifier
           ? _value.deviceIdentifier
           : deviceIdentifier // ignore: cast_nullable_to_non_nullable
               as String?,
-      locale: locale == freezed
+      locale: null == locale
           ? _value.locale
           : locale // ignore: cast_nullable_to_non_nullable
               as String,
-      isFrameVisible: isFrameVisible == freezed
+      isFrameVisible: null == isFrameVisible
           ? _value.isFrameVisible
           : isFrameVisible // ignore: cast_nullable_to_non_nullable
               as bool,
-      isDarkMode: isDarkMode == freezed
+      isDarkMode: null == isDarkMode
           ? _value.isDarkMode
           : isDarkMode // ignore: cast_nullable_to_non_nullable
               as bool,
-      boldText: boldText == freezed
+      boldText: null == boldText
           ? _value.boldText
           : boldText // ignore: cast_nullable_to_non_nullable
               as bool,
-      isVirtualKeyboardVisible: isVirtualKeyboardVisible == freezed
+      isVirtualKeyboardVisible: null == isVirtualKeyboardVisible
           ? _value.isVirtualKeyboardVisible
           : isVirtualKeyboardVisible // ignore: cast_nullable_to_non_nullable
               as bool,
-      disableAnimations: disableAnimations == freezed
+      zoomLevel: freezed == zoomLevel
+          ? _value.zoomLevel
+          : zoomLevel // ignore: cast_nullable_to_non_nullable
+              as int?,
+      disableAnimations: null == disableAnimations
           ? _value.disableAnimations
           : disableAnimations // ignore: cast_nullable_to_non_nullable
               as bool,
-      highContrast: highContrast == freezed
+      highContrast: null == highContrast
           ? _value.highContrast
           : highContrast // ignore: cast_nullable_to_non_nullable
               as bool,
-      accessibleNavigation: accessibleNavigation == freezed
+      accessibleNavigation: null == accessibleNavigation
           ? _value.accessibleNavigation
           : accessibleNavigation // ignore: cast_nullable_to_non_nullable
               as bool,
-      invertColors: invertColors == freezed
+      invertColors: null == invertColors
           ? _value.invertColors
           : invertColors // ignore: cast_nullable_to_non_nullable
               as bool,
-      pluginData: pluginData == freezed
+      pluginData: null == pluginData
           ? _value.pluginData
           : pluginData // ignore: cast_nullable_to_non_nullable
               as Map<String, Map<String, dynamic>>,
-      textScaleFactor: textScaleFactor == freezed
+      textScaleFactor: null == textScaleFactor
           ? _value.textScaleFactor
           : textScaleFactor // ignore: cast_nullable_to_non_nullable
               as double,
-      settings: settings == freezed
+      settings: freezed == settings
           ? _value.settings
           : settings // ignore: cast_nullable_to_non_nullable
               as DevicePreviewSettingsData?,
-      customDevice: customDevice == freezed
+      customDevice: freezed == customDevice
           ? _value.customDevice
           : customDevice // ignore: cast_nullable_to_non_nullable
               as CustomDeviceInfoData?,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $DevicePreviewSettingsDataCopyWith<$Res>? get settings {
     if (_value.settings == null) {
       return null;
     }
 
     return $DevicePreviewSettingsDataCopyWith<$Res>(_value.settings!, (value) {
-      return _then(_value.copyWith(settings: value));
+      return _then(_value.copyWith(settings: value) as $Val);
     });
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $CustomDeviceInfoDataCopyWith<$Res>? get customDevice {
     if (_value.customDevice == null) {
       return null;
     }
 
     return $CustomDeviceInfoDataCopyWith<$Res>(_value.customDevice!, (value) {
-      return _then(_value.copyWith(customDevice: value));
+      return _then(_value.copyWith(customDevice: value) as $Val);
     });
   }
 }
@@ -802,6 +812,7 @@ abstract class _$$_DevicePreviewDataCopyWith<$Res>
           $Res Function(_$_DevicePreviewData) then) =
       __$$_DevicePreviewDataCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {bool isToolbarVisible,
       bool isEnabled,
@@ -812,6 +823,7 @@ abstract class _$$_DevicePreviewDataCopyWith<$Res>
       bool isDarkMode,
       bool boldText,
       bool isVirtualKeyboardVisible,
+      int? zoomLevel,
       bool disableAnimations,
       bool highContrast,
       bool accessibleNavigation,
@@ -829,101 +841,104 @@ abstract class _$$_DevicePreviewDataCopyWith<$Res>
 
 /// @nodoc
 class __$$_DevicePreviewDataCopyWithImpl<$Res>
-    extends _$DevicePreviewDataCopyWithImpl<$Res>
+    extends _$DevicePreviewDataCopyWithImpl<$Res, _$_DevicePreviewData>
     implements _$$_DevicePreviewDataCopyWith<$Res> {
   __$$_DevicePreviewDataCopyWithImpl(
       _$_DevicePreviewData _value, $Res Function(_$_DevicePreviewData) _then)
-      : super(_value, (v) => _then(v as _$_DevicePreviewData));
+      : super(_value, _then);
 
-  @override
-  _$_DevicePreviewData get _value => super._value as _$_DevicePreviewData;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? isToolbarVisible = freezed,
-    Object? isEnabled = freezed,
-    Object? orientation = freezed,
+    Object? isToolbarVisible = null,
+    Object? isEnabled = null,
+    Object? orientation = null,
     Object? deviceIdentifier = freezed,
-    Object? locale = freezed,
-    Object? isFrameVisible = freezed,
-    Object? isDarkMode = freezed,
-    Object? boldText = freezed,
-    Object? isVirtualKeyboardVisible = freezed,
-    Object? disableAnimations = freezed,
-    Object? highContrast = freezed,
-    Object? accessibleNavigation = freezed,
-    Object? invertColors = freezed,
-    Object? pluginData = freezed,
-    Object? textScaleFactor = freezed,
+    Object? locale = null,
+    Object? isFrameVisible = null,
+    Object? isDarkMode = null,
+    Object? boldText = null,
+    Object? isVirtualKeyboardVisible = null,
+    Object? zoomLevel = freezed,
+    Object? disableAnimations = null,
+    Object? highContrast = null,
+    Object? accessibleNavigation = null,
+    Object? invertColors = null,
+    Object? pluginData = null,
+    Object? textScaleFactor = null,
     Object? settings = freezed,
     Object? customDevice = freezed,
   }) {
     return _then(_$_DevicePreviewData(
-      isToolbarVisible: isToolbarVisible == freezed
+      isToolbarVisible: null == isToolbarVisible
           ? _value.isToolbarVisible
           : isToolbarVisible // ignore: cast_nullable_to_non_nullable
               as bool,
-      isEnabled: isEnabled == freezed
+      isEnabled: null == isEnabled
           ? _value.isEnabled
           : isEnabled // ignore: cast_nullable_to_non_nullable
               as bool,
-      orientation: orientation == freezed
+      orientation: null == orientation
           ? _value.orientation
           : orientation // ignore: cast_nullable_to_non_nullable
               as Orientation,
-      deviceIdentifier: deviceIdentifier == freezed
+      deviceIdentifier: freezed == deviceIdentifier
           ? _value.deviceIdentifier
           : deviceIdentifier // ignore: cast_nullable_to_non_nullable
               as String?,
-      locale: locale == freezed
+      locale: null == locale
           ? _value.locale
           : locale // ignore: cast_nullable_to_non_nullable
               as String,
-      isFrameVisible: isFrameVisible == freezed
+      isFrameVisible: null == isFrameVisible
           ? _value.isFrameVisible
           : isFrameVisible // ignore: cast_nullable_to_non_nullable
               as bool,
-      isDarkMode: isDarkMode == freezed
+      isDarkMode: null == isDarkMode
           ? _value.isDarkMode
           : isDarkMode // ignore: cast_nullable_to_non_nullable
               as bool,
-      boldText: boldText == freezed
+      boldText: null == boldText
           ? _value.boldText
           : boldText // ignore: cast_nullable_to_non_nullable
               as bool,
-      isVirtualKeyboardVisible: isVirtualKeyboardVisible == freezed
+      isVirtualKeyboardVisible: null == isVirtualKeyboardVisible
           ? _value.isVirtualKeyboardVisible
           : isVirtualKeyboardVisible // ignore: cast_nullable_to_non_nullable
               as bool,
-      disableAnimations: disableAnimations == freezed
+      zoomLevel: freezed == zoomLevel
+          ? _value.zoomLevel
+          : zoomLevel // ignore: cast_nullable_to_non_nullable
+              as int?,
+      disableAnimations: null == disableAnimations
           ? _value.disableAnimations
           : disableAnimations // ignore: cast_nullable_to_non_nullable
               as bool,
-      highContrast: highContrast == freezed
+      highContrast: null == highContrast
           ? _value.highContrast
           : highContrast // ignore: cast_nullable_to_non_nullable
               as bool,
-      accessibleNavigation: accessibleNavigation == freezed
+      accessibleNavigation: null == accessibleNavigation
           ? _value.accessibleNavigation
           : accessibleNavigation // ignore: cast_nullable_to_non_nullable
               as bool,
-      invertColors: invertColors == freezed
+      invertColors: null == invertColors
           ? _value.invertColors
           : invertColors // ignore: cast_nullable_to_non_nullable
               as bool,
-      pluginData: pluginData == freezed
+      pluginData: null == pluginData
           ? _value._pluginData
           : pluginData // ignore: cast_nullable_to_non_nullable
               as Map<String, Map<String, dynamic>>,
-      textScaleFactor: textScaleFactor == freezed
+      textScaleFactor: null == textScaleFactor
           ? _value.textScaleFactor
           : textScaleFactor // ignore: cast_nullable_to_non_nullable
               as double,
-      settings: settings == freezed
+      settings: freezed == settings
           ? _value.settings
           : settings // ignore: cast_nullable_to_non_nullable
               as DevicePreviewSettingsData?,
-      customDevice: customDevice == freezed
+      customDevice: freezed == customDevice
           ? _value.customDevice
           : customDevice // ignore: cast_nullable_to_non_nullable
               as CustomDeviceInfoData?,
@@ -946,6 +961,7 @@ class _$_DevicePreviewData
       this.isDarkMode = false,
       this.boldText = false,
       this.isVirtualKeyboardVisible = false,
+      this.zoomLevel = null,
       this.disableAnimations = false,
       this.highContrast = false,
       this.accessibleNavigation = false,
@@ -1004,6 +1020,11 @@ class _$_DevicePreviewData
   @JsonKey()
   final bool isVirtualKeyboardVisible;
 
+  /// Current zoom level
+  @override
+  @JsonKey()
+  final int? zoomLevel;
+
   /// Indicate whether animations are disabled.
   @override
   @JsonKey()
@@ -1049,7 +1070,7 @@ class _$_DevicePreviewData
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'DevicePreviewData(isToolbarVisible: $isToolbarVisible, isEnabled: $isEnabled, orientation: $orientation, deviceIdentifier: $deviceIdentifier, locale: $locale, isFrameVisible: $isFrameVisible, isDarkMode: $isDarkMode, boldText: $boldText, isVirtualKeyboardVisible: $isVirtualKeyboardVisible, disableAnimations: $disableAnimations, highContrast: $highContrast, accessibleNavigation: $accessibleNavigation, invertColors: $invertColors, pluginData: $pluginData, textScaleFactor: $textScaleFactor, settings: $settings, customDevice: $customDevice)';
+    return 'DevicePreviewData(isToolbarVisible: $isToolbarVisible, isEnabled: $isEnabled, orientation: $orientation, deviceIdentifier: $deviceIdentifier, locale: $locale, isFrameVisible: $isFrameVisible, isDarkMode: $isDarkMode, boldText: $boldText, isVirtualKeyboardVisible: $isVirtualKeyboardVisible, zoomLevel: $zoomLevel, disableAnimations: $disableAnimations, highContrast: $highContrast, accessibleNavigation: $accessibleNavigation, invertColors: $invertColors, pluginData: $pluginData, textScaleFactor: $textScaleFactor, settings: $settings, customDevice: $customDevice)';
   }
 
   @override
@@ -1067,6 +1088,7 @@ class _$_DevicePreviewData
       ..add(DiagnosticsProperty('boldText', boldText))
       ..add(DiagnosticsProperty(
           'isVirtualKeyboardVisible', isVirtualKeyboardVisible))
+      ..add(DiagnosticsProperty('zoomLevel', zoomLevel))
       ..add(DiagnosticsProperty('disableAnimations', disableAnimations))
       ..add(DiagnosticsProperty('highContrast', highContrast))
       ..add(DiagnosticsProperty('accessibleNavigation', accessibleNavigation))
@@ -1082,69 +1104,79 @@ class _$_DevicePreviewData
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_DevicePreviewData &&
-            const DeepCollectionEquality()
-                .equals(other.isToolbarVisible, isToolbarVisible) &&
-            const DeepCollectionEquality().equals(other.isEnabled, isEnabled) &&
-            const DeepCollectionEquality()
-                .equals(other.orientation, orientation) &&
-            const DeepCollectionEquality()
-                .equals(other.deviceIdentifier, deviceIdentifier) &&
-            const DeepCollectionEquality().equals(other.locale, locale) &&
-            const DeepCollectionEquality()
-                .equals(other.isFrameVisible, isFrameVisible) &&
-            const DeepCollectionEquality()
-                .equals(other.isDarkMode, isDarkMode) &&
-            const DeepCollectionEquality().equals(other.boldText, boldText) &&
-            const DeepCollectionEquality().equals(
-                other.isVirtualKeyboardVisible, isVirtualKeyboardVisible) &&
-            const DeepCollectionEquality()
-                .equals(other.disableAnimations, disableAnimations) &&
-            const DeepCollectionEquality()
-                .equals(other.highContrast, highContrast) &&
-            const DeepCollectionEquality()
-                .equals(other.accessibleNavigation, accessibleNavigation) &&
-            const DeepCollectionEquality()
-                .equals(other.invertColors, invertColors) &&
+            (identical(other.isToolbarVisible, isToolbarVisible) ||
+                other.isToolbarVisible == isToolbarVisible) &&
+            (identical(other.isEnabled, isEnabled) ||
+                other.isEnabled == isEnabled) &&
+            (identical(other.orientation, orientation) ||
+                other.orientation == orientation) &&
+            (identical(other.deviceIdentifier, deviceIdentifier) ||
+                other.deviceIdentifier == deviceIdentifier) &&
+            (identical(other.locale, locale) || other.locale == locale) &&
+            (identical(other.isFrameVisible, isFrameVisible) ||
+                other.isFrameVisible == isFrameVisible) &&
+            (identical(other.isDarkMode, isDarkMode) ||
+                other.isDarkMode == isDarkMode) &&
+            (identical(other.boldText, boldText) ||
+                other.boldText == boldText) &&
+            (identical(
+                    other.isVirtualKeyboardVisible, isVirtualKeyboardVisible) ||
+                other.isVirtualKeyboardVisible == isVirtualKeyboardVisible) &&
+            (identical(other.zoomLevel, zoomLevel) ||
+                other.zoomLevel == zoomLevel) &&
+            (identical(other.disableAnimations, disableAnimations) ||
+                other.disableAnimations == disableAnimations) &&
+            (identical(other.highContrast, highContrast) ||
+                other.highContrast == highContrast) &&
+            (identical(other.accessibleNavigation, accessibleNavigation) ||
+                other.accessibleNavigation == accessibleNavigation) &&
+            (identical(other.invertColors, invertColors) ||
+                other.invertColors == invertColors) &&
             const DeepCollectionEquality()
                 .equals(other._pluginData, _pluginData) &&
-            const DeepCollectionEquality()
-                .equals(other.textScaleFactor, textScaleFactor) &&
-            const DeepCollectionEquality().equals(other.settings, settings) &&
-            const DeepCollectionEquality()
-                .equals(other.customDevice, customDevice));
+            (identical(other.textScaleFactor, textScaleFactor) ||
+                other.textScaleFactor == textScaleFactor) &&
+            (identical(other.settings, settings) ||
+                other.settings == settings) &&
+            (identical(other.customDevice, customDevice) ||
+                other.customDevice == customDevice));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(isToolbarVisible),
-      const DeepCollectionEquality().hash(isEnabled),
-      const DeepCollectionEquality().hash(orientation),
-      const DeepCollectionEquality().hash(deviceIdentifier),
-      const DeepCollectionEquality().hash(locale),
-      const DeepCollectionEquality().hash(isFrameVisible),
-      const DeepCollectionEquality().hash(isDarkMode),
-      const DeepCollectionEquality().hash(boldText),
-      const DeepCollectionEquality().hash(isVirtualKeyboardVisible),
-      const DeepCollectionEquality().hash(disableAnimations),
-      const DeepCollectionEquality().hash(highContrast),
-      const DeepCollectionEquality().hash(accessibleNavigation),
-      const DeepCollectionEquality().hash(invertColors),
+      isToolbarVisible,
+      isEnabled,
+      orientation,
+      deviceIdentifier,
+      locale,
+      isFrameVisible,
+      isDarkMode,
+      boldText,
+      isVirtualKeyboardVisible,
+      zoomLevel,
+      disableAnimations,
+      highContrast,
+      accessibleNavigation,
+      invertColors,
       const DeepCollectionEquality().hash(_pluginData),
-      const DeepCollectionEquality().hash(textScaleFactor),
-      const DeepCollectionEquality().hash(settings),
-      const DeepCollectionEquality().hash(customDevice));
+      textScaleFactor,
+      settings,
+      customDevice);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_DevicePreviewDataCopyWith<_$_DevicePreviewData> get copyWith =>
       __$$_DevicePreviewDataCopyWithImpl<_$_DevicePreviewData>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DevicePreviewDataToJson(this);
+    return _$$_DevicePreviewDataToJson(
+      this,
+    );
   }
 }
 
@@ -1159,6 +1191,7 @@ abstract class _DevicePreviewData implements DevicePreviewData {
       final bool isDarkMode,
       final bool boldText,
       final bool isVirtualKeyboardVisible,
+      final int? zoomLevel,
       final bool disableAnimations,
       final bool highContrast,
       final bool accessibleNavigation,
@@ -1174,70 +1207,73 @@ abstract class _DevicePreviewData implements DevicePreviewData {
   @override
 
   /// Indicate whether the toolbar is visible.
-  bool get isToolbarVisible => throw _privateConstructorUsedError;
+  bool get isToolbarVisible;
   @override
 
   /// Indicate whether the device simulation is enabled.
-  bool get isEnabled => throw _privateConstructorUsedError;
+  bool get isEnabled;
   @override
 
   /// The current orientation of the device
-  Orientation get orientation => throw _privateConstructorUsedError;
+  Orientation get orientation;
   @override
 
   /// The currently selected device.
-  String? get deviceIdentifier => throw _privateConstructorUsedError;
+  String? get deviceIdentifier;
   @override
 
   /// The currently selected device locale.
-  String get locale => throw _privateConstructorUsedError;
+  String get locale;
   @override
 
   /// Indicate whether the frame is currently visible.
-  bool get isFrameVisible => throw _privateConstructorUsedError;
+  bool get isFrameVisible;
   @override
 
   /// Indicate whether the mode is currently dark.
-  bool get isDarkMode => throw _privateConstructorUsedError;
+  bool get isDarkMode;
   @override
 
   /// Indicate whether texts are forced to bold.
-  bool get boldText => throw _privateConstructorUsedError;
+  bool get boldText;
   @override
 
   /// Indicate whether the virtual keyboard is visible.
-  bool get isVirtualKeyboardVisible => throw _privateConstructorUsedError;
+  bool get isVirtualKeyboardVisible;
+  @override
+
+  /// Current zoom level
+  int? get zoomLevel;
   @override
 
   /// Indicate whether animations are disabled.
-  bool get disableAnimations => throw _privateConstructorUsedError;
+  bool get disableAnimations;
   @override
 
   /// Indicate whether the highcontrast mode is activated.
-  bool get highContrast => throw _privateConstructorUsedError;
+  bool get highContrast;
   @override
 
   /// Indicate whether the navigation is in accessible mode.
-  bool get accessibleNavigation => throw _privateConstructorUsedError;
+  bool get accessibleNavigation;
   @override
 
   /// Indicate whether image colors are inverted.
-  bool get invertColors => throw _privateConstructorUsedError;
+  bool get invertColors;
   @override
 
   /// Indicate whether image colors are inverted.
-  Map<String, Map<String, dynamic>> get pluginData =>
-      throw _privateConstructorUsedError;
+  Map<String, Map<String, dynamic>> get pluginData;
   @override
 
   /// The current text scaling factor.
-  double get textScaleFactor => throw _privateConstructorUsedError;
+  double get textScaleFactor;
   @override
-  DevicePreviewSettingsData? get settings => throw _privateConstructorUsedError;
+  DevicePreviewSettingsData? get settings;
   @override
 
   /// The custom device configuration
-  CustomDeviceInfoData? get customDevice => throw _privateConstructorUsedError;
+  CustomDeviceInfoData? get customDevice;
   @override
   @JsonKey(ignore: true)
   _$$_DevicePreviewDataCopyWith<_$_DevicePreviewData> get copyWith =>
@@ -1287,7 +1323,8 @@ mixin _$CustomDeviceInfoData {
 abstract class $CustomDeviceInfoDataCopyWith<$Res> {
   factory $CustomDeviceInfoDataCopyWith(CustomDeviceInfoData value,
           $Res Function(CustomDeviceInfoData) then) =
-      _$CustomDeviceInfoDataCopyWithImpl<$Res>;
+      _$CustomDeviceInfoDataCopyWithImpl<$Res, CustomDeviceInfoData>;
+  @useResult
   $Res call(
       {String id,
       DeviceType type,
@@ -1300,59 +1337,62 @@ abstract class $CustomDeviceInfoDataCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$CustomDeviceInfoDataCopyWithImpl<$Res>
+class _$CustomDeviceInfoDataCopyWithImpl<$Res,
+        $Val extends CustomDeviceInfoData>
     implements $CustomDeviceInfoDataCopyWith<$Res> {
   _$CustomDeviceInfoDataCopyWithImpl(this._value, this._then);
 
-  final CustomDeviceInfoData _value;
   // ignore: unused_field
-  final $Res Function(CustomDeviceInfoData) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? type = freezed,
-    Object? platform = freezed,
-    Object? name = freezed,
+    Object? id = null,
+    Object? type = null,
+    Object? platform = null,
+    Object? name = null,
     Object? rotatedSafeAreas = freezed,
-    Object? safeAreas = freezed,
-    Object? pixelRatio = freezed,
-    Object? screenSize = freezed,
+    Object? safeAreas = null,
+    Object? pixelRatio = null,
+    Object? screenSize = null,
   }) {
     return _then(_value.copyWith(
-      id: id == freezed
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      type: type == freezed
+      type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as DeviceType,
-      platform: platform == freezed
+      platform: null == platform
           ? _value.platform
           : platform // ignore: cast_nullable_to_non_nullable
               as TargetPlatform,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      rotatedSafeAreas: rotatedSafeAreas == freezed
+      rotatedSafeAreas: freezed == rotatedSafeAreas
           ? _value.rotatedSafeAreas
           : rotatedSafeAreas // ignore: cast_nullable_to_non_nullable
               as EdgeInsets?,
-      safeAreas: safeAreas == freezed
+      safeAreas: null == safeAreas
           ? _value.safeAreas
           : safeAreas // ignore: cast_nullable_to_non_nullable
               as EdgeInsets,
-      pixelRatio: pixelRatio == freezed
+      pixelRatio: null == pixelRatio
           ? _value.pixelRatio
           : pixelRatio // ignore: cast_nullable_to_non_nullable
               as double,
-      screenSize: screenSize == freezed
+      screenSize: null == screenSize
           ? _value.screenSize
           : screenSize // ignore: cast_nullable_to_non_nullable
               as Size,
-    ));
+    ) as $Val);
   }
 }
 
@@ -1363,6 +1403,7 @@ abstract class _$$_CustomDeviceInfoDataCopyWith<$Res>
           $Res Function(_$_CustomDeviceInfoData) then) =
       __$$_CustomDeviceInfoDataCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {String id,
       DeviceType type,
@@ -1376,56 +1417,54 @@ abstract class _$$_CustomDeviceInfoDataCopyWith<$Res>
 
 /// @nodoc
 class __$$_CustomDeviceInfoDataCopyWithImpl<$Res>
-    extends _$CustomDeviceInfoDataCopyWithImpl<$Res>
+    extends _$CustomDeviceInfoDataCopyWithImpl<$Res, _$_CustomDeviceInfoData>
     implements _$$_CustomDeviceInfoDataCopyWith<$Res> {
   __$$_CustomDeviceInfoDataCopyWithImpl(_$_CustomDeviceInfoData _value,
       $Res Function(_$_CustomDeviceInfoData) _then)
-      : super(_value, (v) => _then(v as _$_CustomDeviceInfoData));
+      : super(_value, _then);
 
-  @override
-  _$_CustomDeviceInfoData get _value => super._value as _$_CustomDeviceInfoData;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? id = freezed,
-    Object? type = freezed,
-    Object? platform = freezed,
-    Object? name = freezed,
+    Object? id = null,
+    Object? type = null,
+    Object? platform = null,
+    Object? name = null,
     Object? rotatedSafeAreas = freezed,
-    Object? safeAreas = freezed,
-    Object? pixelRatio = freezed,
-    Object? screenSize = freezed,
+    Object? safeAreas = null,
+    Object? pixelRatio = null,
+    Object? screenSize = null,
   }) {
     return _then(_$_CustomDeviceInfoData(
-      id: id == freezed
+      id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
               as String,
-      type: type == freezed
+      type: null == type
           ? _value.type
           : type // ignore: cast_nullable_to_non_nullable
               as DeviceType,
-      platform: platform == freezed
+      platform: null == platform
           ? _value.platform
           : platform // ignore: cast_nullable_to_non_nullable
               as TargetPlatform,
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      rotatedSafeAreas: rotatedSafeAreas == freezed
+      rotatedSafeAreas: freezed == rotatedSafeAreas
           ? _value.rotatedSafeAreas
           : rotatedSafeAreas // ignore: cast_nullable_to_non_nullable
               as EdgeInsets?,
-      safeAreas: safeAreas == freezed
+      safeAreas: null == safeAreas
           ? _value.safeAreas
           : safeAreas // ignore: cast_nullable_to_non_nullable
               as EdgeInsets,
-      pixelRatio: pixelRatio == freezed
+      pixelRatio: null == pixelRatio
           ? _value.pixelRatio
           : pixelRatio // ignore: cast_nullable_to_non_nullable
               as double,
-      screenSize: screenSize == freezed
+      screenSize: null == screenSize
           ? _value.screenSize
           : screenSize // ignore: cast_nullable_to_non_nullable
               as Size,
@@ -1512,41 +1551,38 @@ class _$_CustomDeviceInfoData
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_CustomDeviceInfoData &&
-            const DeepCollectionEquality().equals(other.id, id) &&
-            const DeepCollectionEquality().equals(other.type, type) &&
-            const DeepCollectionEquality().equals(other.platform, platform) &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality()
-                .equals(other.rotatedSafeAreas, rotatedSafeAreas) &&
-            const DeepCollectionEquality().equals(other.safeAreas, safeAreas) &&
-            const DeepCollectionEquality()
-                .equals(other.pixelRatio, pixelRatio) &&
-            const DeepCollectionEquality()
-                .equals(other.screenSize, screenSize));
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.type, type) || other.type == type) &&
+            (identical(other.platform, platform) ||
+                other.platform == platform) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.rotatedSafeAreas, rotatedSafeAreas) ||
+                other.rotatedSafeAreas == rotatedSafeAreas) &&
+            (identical(other.safeAreas, safeAreas) ||
+                other.safeAreas == safeAreas) &&
+            (identical(other.pixelRatio, pixelRatio) ||
+                other.pixelRatio == pixelRatio) &&
+            (identical(other.screenSize, screenSize) ||
+                other.screenSize == screenSize));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(id),
-      const DeepCollectionEquality().hash(type),
-      const DeepCollectionEquality().hash(platform),
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(rotatedSafeAreas),
-      const DeepCollectionEquality().hash(safeAreas),
-      const DeepCollectionEquality().hash(pixelRatio),
-      const DeepCollectionEquality().hash(screenSize));
+  int get hashCode => Object.hash(runtimeType, id, type, platform, name,
+      rotatedSafeAreas, safeAreas, pixelRatio, screenSize);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_CustomDeviceInfoDataCopyWith<_$_CustomDeviceInfoData> get copyWith =>
       __$$_CustomDeviceInfoDataCopyWithImpl<_$_CustomDeviceInfoData>(
           this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_CustomDeviceInfoDataToJson(this);
+    return _$$_CustomDeviceInfoDataToJson(
+      this,
+    );
   }
 }
 
@@ -1568,38 +1604,38 @@ abstract class _CustomDeviceInfoData implements CustomDeviceInfoData {
   @override
 
   /// Identifier of the device.
-  String get id => throw _privateConstructorUsedError;
+  String get id;
   @override
 
   /// The device type.
-  DeviceType get type => throw _privateConstructorUsedError;
+  DeviceType get type;
   @override
 
   /// The device operating system.
-  TargetPlatform get platform => throw _privateConstructorUsedError;
+  TargetPlatform get platform;
   @override
 
   /// The display name of the device.
-  String get name => throw _privateConstructorUsedError;
+  String get name;
   @override
 
   /// The safe areas when the device is in landscape orientation.
   @NullableEdgeInsetsJsonConverter()
-  EdgeInsets? get rotatedSafeAreas => throw _privateConstructorUsedError;
+  EdgeInsets? get rotatedSafeAreas;
   @override
 
   /// The safe areas when the device is in portrait orientation.
   @EdgeInsetsJsonConverter()
-  EdgeInsets get safeAreas => throw _privateConstructorUsedError;
+  EdgeInsets get safeAreas;
   @override
 
   /// The screen pixel density of the device.
-  double get pixelRatio => throw _privateConstructorUsedError;
+  double get pixelRatio;
   @override
 
   /// The size in points of the screen content.
   @SizeJsonConverter()
-  Size get screenSize => throw _privateConstructorUsedError;
+  Size get screenSize;
   @override
   @JsonKey(ignore: true)
   _$$_CustomDeviceInfoDataCopyWith<_$_CustomDeviceInfoData> get copyWith =>
@@ -1635,7 +1671,8 @@ mixin _$DevicePreviewSettingsData {
 abstract class $DevicePreviewSettingsDataCopyWith<$Res> {
   factory $DevicePreviewSettingsDataCopyWith(DevicePreviewSettingsData value,
           $Res Function(DevicePreviewSettingsData) then) =
-      _$DevicePreviewSettingsDataCopyWithImpl<$Res>;
+      _$DevicePreviewSettingsDataCopyWithImpl<$Res, DevicePreviewSettingsData>;
+  @useResult
   $Res call(
       {DevicePreviewToolBarPositionData toolbarPosition,
       DevicePreviewToolBarThemeData toolbarTheme,
@@ -1643,34 +1680,37 @@ abstract class $DevicePreviewSettingsDataCopyWith<$Res> {
 }
 
 /// @nodoc
-class _$DevicePreviewSettingsDataCopyWithImpl<$Res>
+class _$DevicePreviewSettingsDataCopyWithImpl<$Res,
+        $Val extends DevicePreviewSettingsData>
     implements $DevicePreviewSettingsDataCopyWith<$Res> {
   _$DevicePreviewSettingsDataCopyWithImpl(this._value, this._then);
 
-  final DevicePreviewSettingsData _value;
   // ignore: unused_field
-  final $Res Function(DevicePreviewSettingsData) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? toolbarPosition = freezed,
-    Object? toolbarTheme = freezed,
-    Object? backgroundTheme = freezed,
+    Object? toolbarPosition = null,
+    Object? toolbarTheme = null,
+    Object? backgroundTheme = null,
   }) {
     return _then(_value.copyWith(
-      toolbarPosition: toolbarPosition == freezed
+      toolbarPosition: null == toolbarPosition
           ? _value.toolbarPosition
           : toolbarPosition // ignore: cast_nullable_to_non_nullable
               as DevicePreviewToolBarPositionData,
-      toolbarTheme: toolbarTheme == freezed
+      toolbarTheme: null == toolbarTheme
           ? _value.toolbarTheme
           : toolbarTheme // ignore: cast_nullable_to_non_nullable
               as DevicePreviewToolBarThemeData,
-      backgroundTheme: backgroundTheme == freezed
+      backgroundTheme: null == backgroundTheme
           ? _value.backgroundTheme
           : backgroundTheme // ignore: cast_nullable_to_non_nullable
               as DevicePreviewBackgroundThemeData,
-    ));
+    ) as $Val);
   }
 }
 
@@ -1682,6 +1722,7 @@ abstract class _$$_DevicePreviewSettingsDataCopyWith<$Res>
           $Res Function(_$_DevicePreviewSettingsData) then) =
       __$$_DevicePreviewSettingsDataCopyWithImpl<$Res>;
   @override
+  @useResult
   $Res call(
       {DevicePreviewToolBarPositionData toolbarPosition,
       DevicePreviewToolBarThemeData toolbarTheme,
@@ -1690,33 +1731,31 @@ abstract class _$$_DevicePreviewSettingsDataCopyWith<$Res>
 
 /// @nodoc
 class __$$_DevicePreviewSettingsDataCopyWithImpl<$Res>
-    extends _$DevicePreviewSettingsDataCopyWithImpl<$Res>
+    extends _$DevicePreviewSettingsDataCopyWithImpl<$Res,
+        _$_DevicePreviewSettingsData>
     implements _$$_DevicePreviewSettingsDataCopyWith<$Res> {
   __$$_DevicePreviewSettingsDataCopyWithImpl(
       _$_DevicePreviewSettingsData _value,
       $Res Function(_$_DevicePreviewSettingsData) _then)
-      : super(_value, (v) => _then(v as _$_DevicePreviewSettingsData));
+      : super(_value, _then);
 
-  @override
-  _$_DevicePreviewSettingsData get _value =>
-      super._value as _$_DevicePreviewSettingsData;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? toolbarPosition = freezed,
-    Object? toolbarTheme = freezed,
-    Object? backgroundTheme = freezed,
+    Object? toolbarPosition = null,
+    Object? toolbarTheme = null,
+    Object? backgroundTheme = null,
   }) {
     return _then(_$_DevicePreviewSettingsData(
-      toolbarPosition: toolbarPosition == freezed
+      toolbarPosition: null == toolbarPosition
           ? _value.toolbarPosition
           : toolbarPosition // ignore: cast_nullable_to_non_nullable
               as DevicePreviewToolBarPositionData,
-      toolbarTheme: toolbarTheme == freezed
+      toolbarTheme: null == toolbarTheme
           ? _value.toolbarTheme
           : toolbarTheme // ignore: cast_nullable_to_non_nullable
               as DevicePreviewToolBarThemeData,
-      backgroundTheme: backgroundTheme == freezed
+      backgroundTheme: null == backgroundTheme
           ? _value.backgroundTheme
           : backgroundTheme // ignore: cast_nullable_to_non_nullable
               as DevicePreviewBackgroundThemeData,
@@ -1772,31 +1811,31 @@ class _$_DevicePreviewSettingsData
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_DevicePreviewSettingsData &&
-            const DeepCollectionEquality()
-                .equals(other.toolbarPosition, toolbarPosition) &&
-            const DeepCollectionEquality()
-                .equals(other.toolbarTheme, toolbarTheme) &&
-            const DeepCollectionEquality()
-                .equals(other.backgroundTheme, backgroundTheme));
+            (identical(other.toolbarPosition, toolbarPosition) ||
+                other.toolbarPosition == toolbarPosition) &&
+            (identical(other.toolbarTheme, toolbarTheme) ||
+                other.toolbarTheme == toolbarTheme) &&
+            (identical(other.backgroundTheme, backgroundTheme) ||
+                other.backgroundTheme == backgroundTheme));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(toolbarPosition),
-      const DeepCollectionEquality().hash(toolbarTheme),
-      const DeepCollectionEquality().hash(backgroundTheme));
+  int get hashCode =>
+      Object.hash(runtimeType, toolbarPosition, toolbarTheme, backgroundTheme);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_DevicePreviewSettingsDataCopyWith<_$_DevicePreviewSettingsData>
       get copyWith => __$$_DevicePreviewSettingsDataCopyWithImpl<
           _$_DevicePreviewSettingsData>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$_DevicePreviewSettingsDataToJson(this);
+    return _$$_DevicePreviewSettingsDataToJson(
+      this,
+    );
   }
 }
 
@@ -1813,18 +1852,15 @@ abstract class _DevicePreviewSettingsData implements DevicePreviewSettingsData {
   @override
 
   /// The toolbar position.
-  DevicePreviewToolBarPositionData get toolbarPosition =>
-      throw _privateConstructorUsedError;
+  DevicePreviewToolBarPositionData get toolbarPosition;
   @override
 
   /// The theme of the toolbar.
-  DevicePreviewToolBarThemeData get toolbarTheme =>
-      throw _privateConstructorUsedError;
+  DevicePreviewToolBarThemeData get toolbarTheme;
   @override
 
   /// The theme of the background.
-  DevicePreviewBackgroundThemeData get backgroundTheme =>
-      throw _privateConstructorUsedError;
+  DevicePreviewBackgroundThemeData get backgroundTheme;
   @override
   @JsonKey(ignore: true)
   _$$_DevicePreviewSettingsDataCopyWith<_$_DevicePreviewSettingsData>

--- a/device_preview/lib/src/state/state.g.dart
+++ b/device_preview/lib/src/state/state.g.dart
@@ -20,6 +20,7 @@ _$_DevicePreviewData _$$_DevicePreviewDataFromJson(Map<String, dynamic> json) =>
       boldText: json['boldText'] as bool? ?? false,
       isVirtualKeyboardVisible:
           json['isVirtualKeyboardVisible'] as bool? ?? false,
+      zoomLevel: json['zoomLevel'] as int? ?? null,
       disableAnimations: json['disableAnimations'] as bool? ?? false,
       highContrast: json['highContrast'] as bool? ?? false,
       accessibleNavigation: json['accessibleNavigation'] as bool? ?? false,
@@ -44,13 +45,14 @@ Map<String, dynamic> _$$_DevicePreviewDataToJson(
     <String, dynamic>{
       'isToolbarVisible': instance.isToolbarVisible,
       'isEnabled': instance.isEnabled,
-      'orientation': _$OrientationEnumMap[instance.orientation],
+      'orientation': _$OrientationEnumMap[instance.orientation]!,
       'deviceIdentifier': instance.deviceIdentifier,
       'locale': instance.locale,
       'isFrameVisible': instance.isFrameVisible,
       'isDarkMode': instance.isDarkMode,
       'boldText': instance.boldText,
       'isVirtualKeyboardVisible': instance.isVirtualKeyboardVisible,
+      'zoomLevel': instance.zoomLevel,
       'disableAnimations': instance.disableAnimations,
       'highContrast': instance.highContrast,
       'accessibleNavigation': instance.accessibleNavigation,
@@ -86,8 +88,8 @@ Map<String, dynamic> _$$_CustomDeviceInfoDataToJson(
         _$_CustomDeviceInfoData instance) =>
     <String, dynamic>{
       'id': instance.id,
-      'type': _$DeviceTypeEnumMap[instance.type],
-      'platform': _$TargetPlatformEnumMap[instance.platform],
+      'type': _$DeviceTypeEnumMap[instance.type]!,
+      'platform': _$TargetPlatformEnumMap[instance.platform]!,
       'name': instance.name,
       'rotatedSafeAreas': const NullableEdgeInsetsJsonConverter()
           .toJson(instance.rotatedSafeAreas),
@@ -134,11 +136,11 @@ Map<String, dynamic> _$$_DevicePreviewSettingsDataToJson(
         _$_DevicePreviewSettingsData instance) =>
     <String, dynamic>{
       'toolbarPosition':
-          _$DevicePreviewToolBarPositionDataEnumMap[instance.toolbarPosition],
+          _$DevicePreviewToolBarPositionDataEnumMap[instance.toolbarPosition]!,
       'toolbarTheme':
-          _$DevicePreviewToolBarThemeDataEnumMap[instance.toolbarTheme],
+          _$DevicePreviewToolBarThemeDataEnumMap[instance.toolbarTheme]!,
       'backgroundTheme':
-          _$DevicePreviewBackgroundThemeDataEnumMap[instance.backgroundTheme],
+          _$DevicePreviewBackgroundThemeDataEnumMap[instance.backgroundTheme]!,
     };
 
 const _$DevicePreviewToolBarPositionDataEnumMap = {

--- a/device_preview/lib/src/state/store.dart
+++ b/device_preview/lib/src/state/store.dart
@@ -6,10 +6,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../device_preview.dart';
+import '../../device_preview.dart' as device_preview;
 import '../storage/storage.dart';
 import 'custom_device.dart';
 import 'state.dart';
-import '../../device_preview.dart' as device_preview;
 
 /// The store is a container for the current [state] of the device preview.
 ///
@@ -216,6 +216,11 @@ extension DevicePreviewStateHelperExtensions on DevicePreviewStore {
     data = data.copyWith(
       isVirtualKeyboardVisible: !data.isVirtualKeyboardVisible,
     );
+  }
+
+  /// Disable or enable
+  void toggleZoomLevel() {
+    data = data.copyWith(zoomLevel: data.zoomLevel == null ? 100 : null);
   }
 
   /// Switch from light to dark mode.

--- a/device_preview/lib/src/views/tool_panel/sections/device.dart
+++ b/device_preview/lib/src/views/tool_panel/sections/device.dart
@@ -20,6 +20,7 @@ class DeviceSection extends StatelessWidget {
     this.orientation = true,
     this.frameVisibility = true,
     this.virtualKeyboard = true,
+    this.zoom = true,
   }) : super(key: key);
 
   /// Allow to edit the current simulated model.
@@ -33,6 +34,9 @@ class DeviceSection extends StatelessWidget {
 
   /// Allow to show or hide a software keyboard mockup.
   final bool virtualKeyboard;
+
+  /// Allow to change preview zoom
+  final bool zoom;
 
   @override
   Widget build(BuildContext context) {
@@ -58,6 +62,12 @@ class DeviceSection extends StatelessWidget {
     final isFrameVisible = context.select(
       (DevicePreviewStore store) => store.data.isFrameVisible,
     );
+
+    final zoomLevel = context.select(
+      (DevicePreviewStore store) => store.data.zoomLevel,
+    );
+
+    final zoomEnabled = zoomLevel != null;
 
     return ToolPanelSection(
       title: 'Device',
@@ -158,6 +168,42 @@ class DeviceSection extends StatelessWidget {
               state.toggleVirtualKeyboard();
             },
           ),
+        if (zoom) ...[
+          ListTile(
+            key: const Key('zoom'),
+            title: const Text('Zoom level'),
+            subtitle: Text(zoomEnabled ? '$zoomLevel%' : 'Fit screen'),
+            trailing: Opacity(
+              opacity: zoomEnabled ? 0.3 : 1.0,
+              child: const Icon(Icons.fit_screen_outlined),
+            ),
+            onTap: () {
+              final state = context.read<DevicePreviewStore>();
+              state.toggleZoomLevel();
+            },
+          ),
+          ListTile(
+            key: const Key('zoom-level-slider'),
+            title: Slider(
+              value: zoomLevel?.toDouble() ?? 100,
+              onChanged: zoomEnabled
+                  ? (v) {
+                      final state = context.read<DevicePreviewStore>();
+                      state.data = state.data.copyWith(zoomLevel: v.toInt());
+                    }
+                  : null,
+              min: 25,
+              max: 200,
+              divisions: 7,
+            ),
+            onTap: !zoomEnabled
+                ? () {
+                    final state = context.read<DevicePreviewStore>();
+                    state.toggleZoomLevel();
+                  }
+                : null,
+          ),
+        ],
       ],
     );
   }


### PR DESCRIPTION
- `device_frame`: I fixed the size handling of device frames. The specified `frameSize` and the painted dimensions were twice as big as should be. This is necessary to eliminate scaling. The behaviour can be changed by `DeviceFrame(fitContainer)` parameter. The default value is `true`, so nothing changes to current users. If `fitContainer` set to `false`, the `screenSize` is used to calculate whole device frame (scales by ratio of `screenSize` and `screenPath`). 
- `device_preview`: I added a zoom control to the tool panel. Defaults to fit the screen, so nothing changes to current users. When zoom enabled, the device frame is wrapped into a `InteractiveViewer` with scaling disabled (scaling handled by zoom control). The device can be moved outside the frame and panning is ignored inside that. 