### PR TITLE
Added `clipScreen` constructor arg

### DIFF
--- a/device_frame/lib/src/frame.dart
+++ b/device_frame/lib/src/frame.dart
@@ -43,6 +43,12 @@ class DeviceFrame extends StatelessWidget {
   /// only the screen is displayed.
   final bool isFrameVisible;
 
+  /// Indicated whether the screen should be clipped to
+  /// match the device frame.
+  ///
+  /// Mostly only useful if [isFrameVisible] is also false.
+  final bool clipScreen;
+
   /// Displays the given [screen] into the given [info]
   /// simulated device.
   ///
@@ -57,6 +63,7 @@ class DeviceFrame extends StatelessWidget {
     required this.screen,
     this.orientation = Orientation.portrait,
     this.isFrameVisible = true,
+    this.clipScreen = true,
   }) : super(key: key);
 
   /// Creates a [MediaQuery] from the given device [info], and for the current device [orientation].
@@ -150,9 +157,9 @@ class DeviceFrame extends StatelessWidget {
             width: bounds.width,
             height: bounds.height,
             child: ClipPath(
-              clipper: _ScreenClipper(
+              clipper: clipScreen ? _ScreenClipper(
                 device.screenPath,
-              ),
+              ) : null,
               child: FittedBox(
                 child: _screen(context, device),
               ),

--- a/device_frame/lib/src/frame.dart
+++ b/device_frame/lib/src/frame.dart
@@ -43,7 +43,7 @@ class DeviceFrame extends StatelessWidget {
   /// only the screen is displayed.
   final bool isFrameVisible;
 
-  /// Indicated whether the screen should be clipped to
+  /// Indicates whether the screen should be clipped to
   /// match the device frame.
   ///
   /// Mostly only useful if [isFrameVisible] is also false.


### PR DESCRIPTION
I added an arg that allows you to disable clipping the screen to match the device frame.

This is useful if you want to preview the output for a given device (pixel ratio, density, resolution, etc) without the device frame or clipping. I'm using this to auto-generate store screenshots from a Flutter integration script.