### PR TITLE
Fixed bug when taking multiple screenshots

### DIFF
--- a/plugins/device_preview_screenshot/lib/src/section.dart
+++ b/plugins/device_preview_screenshot/lib/src/section.dart
@@ -1,6 +1,6 @@
 import 'package:device_preview/device_preview.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
 
 import 'processors/base64.dart';
 import 'processors/processor.dart';
@@ -95,7 +95,7 @@ class _DevicePreviewScreenshotState extends State<DevicePreviewScreenshot> {
                     });
                     try {
                       final initialDevice =
-                          DevicePreview.selectedDevice(context);
+                          context.read<DevicePreviewStore>().deviceInfo;
                       for (var device
                           in DevicePreview.availableDeviceIdentifiers(
                               context)) {

--- a/plugins/device_preview_screenshot/pubspec.yaml
+++ b/plugins/device_preview_screenshot/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   path: ^1.8.0
+  provider: ^6.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
When taking multiple screenshots, it would fail with error:

> Tried to use `context.select` outside of the  method of a widget.
>
> Any usage other than inside the  method of a widget are not supported.

Since `DevicePreviewStore` is being retrieved to check the current device, to reset it after we're done taking screenshots, I think `context.read` should do, as listening to changes is not needed.