### PR TITLE
Fix GHSA-3hpf-ff72-j67p vulnerability

### DIFF
--- a/device_preview/pubspec.yaml
+++ b/device_preview/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   device_frame: ^1.2.0
   freezed_annotation: ^2.4.1
   json_annotation: ^4.9.0
-  shared_preferences: ^2.2.3
+  shared_preferences: ^2.2.4
   collection: ^1.18.0
 
 dev_dependencies:


### PR DESCRIPTION
A vulnerability was detected on shared_preferences_android, upgrading the version of the library fixes the issue. 