### PR TITLE
fix: virtual keyboard has incorrect minHeight causing overflow

### DIFF
--- a/device_frame/lib/src/keyboard/virtual_keyboard.dart
+++ b/device_frame/lib/src/keyboard/virtual_keyboard.dart
@@ -86,7 +86,7 @@ class _VirtualKeyboard extends StatelessWidget {
     double? height,
   }) : height = height ?? minHeight;
 
-  static const double minHeight = 214;
+  static const double minHeight = 248;
   final double height;
   static const double spacing = 22;
 


### PR DESCRIPTION
In last edit, spacing was increased from 12 to  22, but this was not reflected in `minHeight` causing to overflow when used in `DeviceFrame`