### PR TITLE
device_preview: support Flutter 3.47 hit tests

### DIFF
--- a/device_preview/lib/src/binding/preview_platform_dispatcher.dart
+++ b/device_preview/lib/src/binding/preview_platform_dispatcher.dart
@@ -375,6 +375,12 @@ class PreviewPlatformDispatcher implements ui.PlatformDispatcher {
   set onKeyData(ui.KeyDataCallback? callback) => host.onKeyData = callback;
 
   @override
+  ui.HitTestCallback? get onHitTest => host.onHitTest;
+
+  @override
+  set onHitTest(ui.HitTestCallback? callback) => host.onHitTest = callback;
+
+  @override
   ui.TimingsCallback? get onReportTimings => host.onReportTimings;
 
   @override

--- a/device_preview/pubspec.yaml
+++ b/device_preview/pubspec.yaml
@@ -11,7 +11,7 @@ issue_tracker: https://github.com/aloisdeniel/flutter_device_preview/issues
 
 environment:
   sdk: '>=3.8.0 <4.0.0'
-  flutter: '>=3.44.0'
+  flutter: '>=3.47.0'
 
 dependencies:
   flutter:

--- a/device_preview/test/binding/fakes.dart
+++ b/device_preview/test/binding/fakes.dart
@@ -333,6 +333,9 @@ class FakePlatformDispatcher implements ui.PlatformDispatcher {
   ui.KeyDataCallback? onKeyData;
 
   @override
+  ui.HitTestCallback? onHitTest;
+
+  @override
   ui.TimingsCallback? onReportTimings;
 
   @override

--- a/device_preview/test/binding/preview_platform_dispatcher_test.dart
+++ b/device_preview/test/binding/preview_platform_dispatcher_test.dart
@@ -129,6 +129,8 @@ void main() {
 
     test('pass-through callbacks delegate directly to the host', () {
       void callback() {}
+      ui.HitTestResponse hitTest(ui.HitTestRequest _) =>
+          ui.HitTestResponse.empty;
       dispatcher.onSystemFontFamilyChanged = callback;
       expect(host.onSystemFontFamilyChanged, same(callback));
       expect(dispatcher.onSystemFontFamilyChanged, same(callback));
@@ -140,6 +142,9 @@ void main() {
       expect(host.onPlatformConfigurationChanged, same(callback));
       dispatcher.onDrawFrame = callback;
       expect(host.onDrawFrame, same(callback));
+      dispatcher.onHitTest = hitTest;
+      expect(host.onHitTest, same(hitTest));
+      expect(dispatcher.onHitTest, same(hitTest));
     });
 
     test('scaleFontSize delegates to the host scaler', () {


### PR DESCRIPTION
Delegate Flutter 3.47 hit-test callbacks through PreviewPlatformDispatcher and update the fake dispatcher. Set Flutter 3.47 as the minimum supported version and verify the new callback path.